### PR TITLE
Represent null confidential commitments as a NULL pointer.

### DIFF
--- a/C/include/simplicity/elements.h
+++ b/C/include/simplicity/elements.h
@@ -22,10 +22,9 @@ typedef struct rawScript {
 
 /* A structure representing data for one output from an Elements transaction.
  *
- * Invariant: unsigned char asset[asset[0] == 0 ? 1 : 33];
- *            unsigned char value[value[0] == 0 ? 1 :
- *                                value[0] == 1 ? 9 : 33];
- *            unsigned char nonce[nonce[0] == 0 ? 1 : 33];
+ * Invariant: unsigned char asset[33] or asset == NULL;
+ *            unsigned char value[value[0] == 1 ? 9 : 33] or value == NULL;
+ *            unsigned char nonce[33] or nonce == NULL;
  */
 typedef struct rawOutput {
   const unsigned char* asset;
@@ -37,15 +36,12 @@ typedef struct rawOutput {
 /* A structure representing data for one input from an Elements transaction, plus the TXO data of the output being redeemed.
  *
  * Invariant: uint8_t prevTxid[32];
- *            uint8_t issuance.blindingNonce[32];
- *            uint8_t issuance.assetEntropy[32];
- *            unsigned char issuance.amount[issuance.amount[0] == 0 ? 1 :
- *                                          issuance.amount[0] == 1 ? 9 : 33];
- *            unsigned char issuance.inflationKeys[issuance.inflationKeys[0] == 0 ? 1 :
- *                                                 issuance.inflaitonKeys[0] == 1 ? 9 : 33];
- *            unsigned char txo.asset[txo.asset[0] == 0 ? 1 : 33];
- *            unsigned char txo.value[txo.value[0] == 0 ? 1 :
- *                                    txo.value[0] == 1 ? 9 : 33];
+ *            uint8_t issuance.blindingNonce[32] or (issuance.amount == NULL and issuance.inflationKeys == NULL);
+ *            uint8_t issuance.assetEntropy[32] or (issuance.amount == NULL and issuance.inflationKeys == NULL);
+ *            unsigned char issuance.amount[issuance.amount[0] == 1 ? 9 : 33] or issuance.amount == NULL;
+ *            unsigned char issuance.inflationKeys[issuance.inflaitonKeys[0] == 1 ? 9 : 33] or issuance.inflationKeys == NULL;
+ *            unsigned char txo.asset[33] or txo.asset == NULL;
+ *            unsigned char txo.value[txo.value[0] == 1 ? 9 : 33] or txo.value == NULL;
  */
 typedef struct rawInput {
   const uint8_t* prevTxid;

--- a/C/primitive/elements.c
+++ b/C/primitive/elements.c
@@ -133,38 +133,38 @@ static void hashScriptPubKey(sha256_midstate* result, const rawScript* scriptPub
 /* Initialize a 'confidential' asset or 'confidential' nonce from an unsigned char array from a 'rawTransaction'.
  *
  * Precondition: NULL != conf;
- *               unsigned char rawConf[rawConf[0] == 0x00 ? 1 : 33]
+ *               unsigned char rawConf[33] or rawConf == NULL;
  */
 static void copyRawConfidential(confidential* conf, const unsigned char* rawConf) {
-  if (0 == rawConf[0]) {
+  if (rawConf) {
+    *conf = (confidential){ .prefix = 0x01 == rawConf[0] ? EXPLICIT
+                                    : 0x01 == (0x01 & rawConf[0]) ? ODD_Y
+                                    : EVEN_Y
+                          };
+    sha256_toMidstate(conf->data.s, &rawConf[1]);
+  } else {
     *conf = (confidential){0};
-    return;
   }
-  *conf = (confidential){ .prefix = 0x01 == rawConf[0] ? EXPLICIT
-                                  : 0x01 == (0x01 & rawConf[0]) ? ODD_Y
-                                  : EVEN_Y
-                        };
-  sha256_toMidstate(conf->data.s, &rawConf[1]);
 }
 
 /* Initialize a 'confAmount' from an unsigned char array from a 'rawTransaction'.
  *
  * Precondition: NULL != amt;
- *               unsigned char rawAmt[rawAmt[0] == 0x00 ? 1 :
- *                                    rawAmt[0] == 0x01 ? 9 : 33]
+ *               unsigned char rawAmt[rawAmt[0] == 0x01 ? 9 : 33] or rawAmt == NULL
  */
 static void copyRawAmt(confAmount* amt, const unsigned char* rawAmt) {
-  switch (rawAmt[0]) {
-   case 0x00:
+  if (rawAmt) {
+    switch (rawAmt[0]) {
+     case 0x01:
+      amt->prefix = EXPLICIT;
+      amt->explicit = ReadBE64(&rawAmt[1]);
+      return;
+     default:
+      amt->prefix = 0x01 == (0x01 & rawAmt[0]) ? ODD_Y : EVEN_Y;
+      sha256_toMidstate(amt->confidential.s, &rawAmt[1]);
+    }
+  } else {
     amt->prefix = NONE;
-    return;
-   case 0x01:
-    amt->prefix = EXPLICIT;
-    amt->explicit = ReadBE64(&rawAmt[1]);
-    return;
-   default:
-    amt->prefix = 0x01 == (0x01 & rawAmt[0]) ? ODD_Y : EVEN_Y;
-    sha256_toMidstate(amt->confidential.s, &rawAmt[1]);
   }
 }
 
@@ -182,7 +182,7 @@ static void copyInput(sigInput* result, const rawInput* input) {
   hashScriptPubKey(&result->txo.scriptPubKey, &input->txo.scriptPubKey);
   copyRawConfidential(&result->txo.asset, input->txo.asset);
   copyRawAmt(&result->txo.amt, input->txo.value);
-  if (input->issuance.amount[0] || input->issuance.inflationKeys[0]) {
+  if (input->issuance.amount || input->issuance.inflationKeys) {
     sha256_toMidstate(result->issuance.blindingNonce.s, input->issuance.blindingNonce);
     if (0 == result->issuance.blindingNonce.s[0] && 0 == result->issuance.blindingNonce.s[1] &&
         0 == result->issuance.blindingNonce.s[2] && 0 == result->issuance.blindingNonce.s[3] &&

--- a/C/test.c
+++ b/C/test.c
@@ -247,11 +247,7 @@ static void test_elements(void) {
                    , .prevIx = 0
                    , .sequence = 0xfffffffe
                    , .isPegin = false
-                   , .issuance = { .amount = (unsigned char[1]){"\x00"}
-                                 , .inflationKeys = (unsigned char[1]){"\x00"}
-                                 , .blindingNonce = (uint8_t[32]){0}
-                                 , .assetEntropy = (uint8_t[32]){0}
-                                 }
+                   , .issuance = {0}
                    , .txo = { .asset = (unsigned char[33]){"\x01\x23\x0f\x4f\x5d\x4b\x7c\x6f\xa8\x45\x80\x6e\xe4\xf6\x77\x13\x45\x9e\x1b\x69\xe8\xe6\x0f\xce\xe2\xe4\x94\x0c\x7a\x0d\x5d\xe1\xb2"}
                             , .value = (unsigned char[9]){"\x01\x00\x00\x00\x02\x54\x0b\xe4\x00"}
                             , .scriptPubKey = {0}
@@ -259,14 +255,14 @@ static void test_elements(void) {
       , .output = (rawOutput[])
                   { { .asset = (unsigned char[33]){"\x01\x23\x0f\x4f\x5d\x4b\x7c\x6f\xa8\x45\x80\x6e\xe4\xf6\x77\x13\x45\x9e\x1b\x69\xe8\xe6\x0f\xce\xe2\xe4\x94\x0c\x7a\x0d\x5d\xe1\xb2"}
                     , .value = (unsigned char[9]){"\x01\x00\x00\x00\x02\x54\x0b\xd7\x1c"}
-                    , .nonce = (unsigned char[1]){"\x00"}
+                    , .nonce = NULL
                     , .scriptPubKey = { .code = (unsigned char [26]){"\x19\x76\xa9\x14\x48\x63\x3e\x2c\x0e\xe9\x49\x5d\xd3\xf9\xc4\x37\x32\xc4\x7f\x47\x02\xa3\x62\xc8\x88\xac"}
                                       , .len = 26
                                       }
                     }
                   , { .asset = (unsigned char[33]){"\x01\x23\x0f\x4f\x5d\x4b\x7c\x6f\xa8\x45\x80\x6e\xe4\xf6\x77\x13\x45\x9e\x1b\x69\xe8\xe6\x0f\xce\xe2\xe4\x94\x0c\x7a\x0d\x5d\xe1\xb2"}
                     , .value = (unsigned char[9]){"\x01\x00\x00\x00\x00\x00\x00\x0c\xe4"}
-                    , .nonce = (unsigned char[1]){"\x00"}
+                    , .nonce = NULL
                     , .scriptPubKey = {0}
                   } }
       , .numInputs = 1
@@ -316,11 +312,7 @@ static void test_elements(void) {
                    , .prevIx = 0
                    , .sequence = 0xffffffff /* Here is the modification. */
                    , .isPegin = false
-                   , .issuance = { .amount = (unsigned char[1]){"\x00"}
-                                 , .inflationKeys = (unsigned char[1]){"\x00"}
-                                 , .blindingNonce = (uint8_t[32]){0}
-                                 , .assetEntropy = (uint8_t[32]){0}
-                                 }
+                   , .issuance = {0}
                    , .txo = { .asset = (unsigned char[33]){"\x01\x23\x0f\x4f\x5d\x4b\x7c\x6f\xa8\x45\x80\x6e\xe4\xf6\x77\x13\x45\x9e\x1b\x69\xe8\xe6\x0f\xce\xe2\xe4\x94\x0c\x7a\x0d\x5d\xe1\xb2"}
                             , .value = (unsigned char[9]){"\x01\x00\x00\x00\x02\x54\x0b\xe4\x00"}
                             , .scriptPubKey = {0}
@@ -328,14 +320,14 @@ static void test_elements(void) {
       , .output = (rawOutput[])
                   { { .asset = (unsigned char[33]){"\x01\x23\x0f\x4f\x5d\x4b\x7c\x6f\xa8\x45\x80\x6e\xe4\xf6\x77\x13\x45\x9e\x1b\x69\xe8\xe6\x0f\xce\xe2\xe4\x94\x0c\x7a\x0d\x5d\xe1\xb2"}
                     , .value = (unsigned char[9]){"\x01\x00\x00\x00\x02\x54\x0b\xd7\x1c"}
-                    , .nonce = (unsigned char[1]){"\x00"}
+                    , .nonce = NULL
                     , .scriptPubKey = { .code = (unsigned char [26]){"\x19\x76\xa9\x14\x48\x63\x3e\x2c\x0e\xe9\x49\x5d\xd3\xf9\xc4\x37\x32\xc4\x7f\x47\x02\xa3\x62\xc8\x88\xac"}
                                       , .len = 26
                                       }
                     }
                   , { .asset = (unsigned char[33]){"\x01\x23\x0f\x4f\x5d\x4b\x7c\x6f\xa8\x45\x80\x6e\xe4\xf6\x77\x13\x45\x9e\x1b\x69\xe8\xe6\x0f\xce\xe2\xe4\x94\x0c\x7a\x0d\x5d\xe1\xb2"}
                     , .value = (unsigned char[9]){"\x01\x00\x00\x00\x00\x00\x00\x0c\xe4"}
-                    , .nonce = (unsigned char[1]){"\x00"}
+                    , .nonce = NULL
                     , .scriptPubKey = {0}
                   } }
       , .numInputs = 1


### PR DESCRIPTION
Given how Elements' CConfidentialCommitment internal data structure works, it is easier to use a NULL pointer for NULL confidential commitments.

We also now explicitly allow issuance.blindingNonce and assetEntropy to be NULL pointers for a NULL issuance.
This allows us set issuance = {0} for NULL issuances.
This was alreayd implicitly allowed, so this bit is only a documentation change.