### PR TITLE
Minor ammendments to the Elements API

### DIFF
--- a/C/include/simplicity/elements.h
+++ b/C/include/simplicity/elements.h
@@ -22,10 +22,9 @@ typedef struct rawScript {
 
 /* A structure representing data for one output from an Elements transaction.
  *
- * Invariant: unsigned char asset[asset[0] == 0 ? 1 : 33];
- *            unsigned char value[value[0] == 0 ? 1 :
- *                                value[0] == 1 ? 9 : 33];
- *            unsigned char nonce[nonce[0] == 0 ? 1 : 33];
+ * Invariant: unsigned char asset[33] or asset == NULL;
+ *            unsigned char value[value[0] == 1 ? 9 : 33] or value == NULL;
+ *            unsigned char nonce[33] or nonce == NULL;
  */
 typedef struct rawOutput {
   const unsigned char* asset;
@@ -37,15 +36,12 @@ typedef struct rawOutput {
 /* A structure representing data for one input from an Elements transaction, plus the TXO data of the output being redeemed.
  *
  * Invariant: uint8_t prevTxid[32];
- *            uint8_t issuance.blindingNonce[32];
- *            uint8_t issuance.assetEntropy[32];
- *            unsigned char issuance.amount[issuance.amount[0] == 0 ? 1 :
- *                                          issuance.amount[0] == 1 ? 9 : 33];
- *            unsigned char issuance.inflationKeys[issuance.inflationKeys[0] == 0 ? 1 :
- *                                                 issuance.inflaitonKeys[0] == 1 ? 9 : 33];
- *            unsigned char txo.asset[txo.asset[0] == 0 ? 1 : 33];
- *            unsigned char txo.value[txo.value[0] == 0 ? 1 :
- *                                    txo.value[0] == 1 ? 9 : 33];
+ *            uint8_t issuance.blindingNonce[32] or (issuance.amount == NULL and issuance.inflationKeys == NULL);
+ *            uint8_t issuance.assetEntropy[32] or (issuance.amount == NULL and issuance.inflationKeys == NULL);
+ *            unsigned char issuance.amount[issuance.amount[0] == 1 ? 9 : 33] or issuance.amount == NULL;
+ *            unsigned char issuance.inflationKeys[issuance.inflaitonKeys[0] == 1 ? 9 : 33] or issuance.inflationKeys == NULL;
+ *            unsigned char txo.asset[33] or txo.asset == NULL;
+ *            unsigned char txo.value[txo.value[0] == 1 ? 9 : 33] or txo.value == NULL;
  */
 typedef struct rawInput {
   const uint8_t* prevTxid;

--- a/C/include/simplicity/elements.h
+++ b/C/include/simplicity/elements.h
@@ -35,19 +35,19 @@ typedef struct rawOutput {
 
 /* A structure representing data for one input from an Elements transaction, plus the TXO data of the output being redeemed.
  *
- * Invariant: uint8_t prevTxid[32];
- *            uint8_t issuance.blindingNonce[32] or (issuance.amount == NULL and issuance.inflationKeys == NULL);
- *            uint8_t issuance.assetEntropy[32] or (issuance.amount == NULL and issuance.inflationKeys == NULL);
+ * Invariant: unsigned char prevTxid[32];
+ *            unsigned char issuance.blindingNonce[32] or (issuance.amount == NULL and issuance.inflationKeys == NULL);
+ *            unsigned char issuance.assetEntropy[32] or (issuance.amount == NULL and issuance.inflationKeys == NULL);
  *            unsigned char issuance.amount[issuance.amount[0] == 1 ? 9 : 33] or issuance.amount == NULL;
  *            unsigned char issuance.inflationKeys[issuance.inflaitonKeys[0] == 1 ? 9 : 33] or issuance.inflationKeys == NULL;
  *            unsigned char txo.asset[33] or txo.asset == NULL;
  *            unsigned char txo.value[txo.value[0] == 1 ? 9 : 33] or txo.value == NULL;
  */
 typedef struct rawInput {
-  const uint8_t* prevTxid;
+  const unsigned char* prevTxid;
   struct {
-    const uint8_t* blindingNonce;
-    const uint8_t* assetEntropy;
+    const unsigned char* blindingNonce;
+    const unsigned char* assetEntropy;
     const unsigned char* amount;
     const unsigned char* inflationKeys;
   } issuance;

--- a/C/include/simplicity/elements.h
+++ b/C/include/simplicity/elements.h
@@ -98,10 +98,10 @@ extern transaction* elements_simplicity_mallocTransaction(const rawTransaction* 
  *
  * Precondition: NULL != success;
  *               NULL != tx;
- *               NULL != cmr implies uint32_t cmr[8]
- *               NULL != wmr implies uint32_t wmr[8]
+ *               NULL != cmr implies unsigned char cmr[32]
+ *               NULL != wmr implies unsigned char wmr[32]
  *               NULL != file;
  */
 extern bool elements_simplicity_execSimplicity(bool* success, const transaction* tx, uint_fast32_t ix,
-                                               const uint32_t* cmr, const uint32_t* wmr, FILE* file);
+                                               const unsigned char* cmr, const unsigned char* wmr, FILE* file);
 #endif

--- a/C/test.c
+++ b/C/test.c
@@ -247,11 +247,7 @@ static void test_elements(void) {
                    , .prevIx = 0
                    , .sequence = 0xfffffffe
                    , .isPegin = false
-                   , .issuance = { .amount = (unsigned char[1]){"\x00"}
-                                 , .inflationKeys = (unsigned char[1]){"\x00"}
-                                 , .blindingNonce = (uint8_t[32]){0}
-                                 , .assetEntropy = (uint8_t[32]){0}
-                                 }
+                   , .issuance = {0}
                    , .txo = { .asset = (unsigned char[33]){"\x01\x23\x0f\x4f\x5d\x4b\x7c\x6f\xa8\x45\x80\x6e\xe4\xf6\x77\x13\x45\x9e\x1b\x69\xe8\xe6\x0f\xce\xe2\xe4\x94\x0c\x7a\x0d\x5d\xe1\xb2"}
                             , .value = (unsigned char[9]){"\x01\x00\x00\x00\x02\x54\x0b\xe4\x00"}
                             , .scriptPubKey = {0}
@@ -259,14 +255,14 @@ static void test_elements(void) {
       , .output = (rawOutput[])
                   { { .asset = (unsigned char[33]){"\x01\x23\x0f\x4f\x5d\x4b\x7c\x6f\xa8\x45\x80\x6e\xe4\xf6\x77\x13\x45\x9e\x1b\x69\xe8\xe6\x0f\xce\xe2\xe4\x94\x0c\x7a\x0d\x5d\xe1\xb2"}
                     , .value = (unsigned char[9]){"\x01\x00\x00\x00\x02\x54\x0b\xd7\x1c"}
-                    , .nonce = (unsigned char[1]){"\x00"}
+                    , .nonce = NULL
                     , .scriptPubKey = { .code = (unsigned char [26]){"\x19\x76\xa9\x14\x48\x63\x3e\x2c\x0e\xe9\x49\x5d\xd3\xf9\xc4\x37\x32\xc4\x7f\x47\x02\xa3\x62\xc8\x88\xac"}
                                       , .len = 26
                                       }
                     }
                   , { .asset = (unsigned char[33]){"\x01\x23\x0f\x4f\x5d\x4b\x7c\x6f\xa8\x45\x80\x6e\xe4\xf6\x77\x13\x45\x9e\x1b\x69\xe8\xe6\x0f\xce\xe2\xe4\x94\x0c\x7a\x0d\x5d\xe1\xb2"}
                     , .value = (unsigned char[9]){"\x01\x00\x00\x00\x00\x00\x00\x0c\xe4"}
-                    , .nonce = (unsigned char[1]){"\x00"}
+                    , .nonce = NULL
                     , .scriptPubKey = {0}
                   } }
       , .numInputs = 1
@@ -316,11 +312,7 @@ static void test_elements(void) {
                    , .prevIx = 0
                    , .sequence = 0xffffffff /* Here is the modification. */
                    , .isPegin = false
-                   , .issuance = { .amount = (unsigned char[1]){"\x00"}
-                                 , .inflationKeys = (unsigned char[1]){"\x00"}
-                                 , .blindingNonce = (uint8_t[32]){0}
-                                 , .assetEntropy = (uint8_t[32]){0}
-                                 }
+                   , .issuance = {0}
                    , .txo = { .asset = (unsigned char[33]){"\x01\x23\x0f\x4f\x5d\x4b\x7c\x6f\xa8\x45\x80\x6e\xe4\xf6\x77\x13\x45\x9e\x1b\x69\xe8\xe6\x0f\xce\xe2\xe4\x94\x0c\x7a\x0d\x5d\xe1\xb2"}
                             , .value = (unsigned char[9]){"\x01\x00\x00\x00\x02\x54\x0b\xe4\x00"}
                             , .scriptPubKey = {0}
@@ -328,14 +320,14 @@ static void test_elements(void) {
       , .output = (rawOutput[])
                   { { .asset = (unsigned char[33]){"\x01\x23\x0f\x4f\x5d\x4b\x7c\x6f\xa8\x45\x80\x6e\xe4\xf6\x77\x13\x45\x9e\x1b\x69\xe8\xe6\x0f\xce\xe2\xe4\x94\x0c\x7a\x0d\x5d\xe1\xb2"}
                     , .value = (unsigned char[9]){"\x01\x00\x00\x00\x02\x54\x0b\xd7\x1c"}
-                    , .nonce = (unsigned char[1]){"\x00"}
+                    , .nonce = NULL
                     , .scriptPubKey = { .code = (unsigned char [26]){"\x19\x76\xa9\x14\x48\x63\x3e\x2c\x0e\xe9\x49\x5d\xd3\xf9\xc4\x37\x32\xc4\x7f\x47\x02\xa3\x62\xc8\x88\xac"}
                                       , .len = 26
                                       }
                     }
                   , { .asset = (unsigned char[33]){"\x01\x23\x0f\x4f\x5d\x4b\x7c\x6f\xa8\x45\x80\x6e\xe4\xf6\x77\x13\x45\x9e\x1b\x69\xe8\xe6\x0f\xce\xe2\xe4\x94\x0c\x7a\x0d\x5d\xe1\xb2"}
                     , .value = (unsigned char[9]){"\x01\x00\x00\x00\x00\x00\x00\x0c\xe4"}
-                    , .nonce = (unsigned char[1]){"\x00"}
+                    , .nonce = NULL
                     , .scriptPubKey = {0}
                   } }
       , .numInputs = 1

--- a/C/test.c
+++ b/C/test.c
@@ -239,6 +239,8 @@ static void test_occursCheck(void) {
 }
 
 static void test_elements(void) {
+  unsigned char cmr[32], wmr[32];
+
   printf("Test elements\n");
   {
     rawTransaction testTx1 = (rawTransaction)
@@ -271,12 +273,14 @@ static void test_elements(void) {
       , .lockTime = 0x00000000
       };
     transaction* tx1 = elements_simplicity_mallocTransaction(&testTx1);
+    sha256_fromMidstate(cmr, elementsCheckSigHashAllTx1_cmr);
+    sha256_fromMidstate(wmr, elementsCheckSigHashAllTx1_wmr);
     if (tx1) {
       successes++;
       bool execResult;
       {
         FILE* file = fmemopen_rb(elementsCheckSigHashAllTx1, sizeof_elementsCheckSigHashAllTx1);
-        if (elements_simplicity_execSimplicity(&execResult, tx1, 0, elementsCheckSigHashAllTx1_cmr, elementsCheckSigHashAllTx1_wmr, file) && execResult) {
+        if (elements_simplicity_execSimplicity(&execResult, tx1, 0, cmr, wmr, file) && execResult) {
           successes++;
         } else {
           failures++;


### PR DESCRIPTION
* Null commitments are now represented as `NULL` pointers.
* Uniformly use `unsigned char` over `uint8_t`.
* Merkle roots are passed via an `unsigned char[32]` array instead of the `uint32_t[8]` array.