### PR TITLE
Fix various heap management errors.

### DIFF
--- a/C/deserialize.c
+++ b/C/deserialize.c
@@ -382,6 +382,7 @@ int32_t decodeMallocDag(dag_node** dag, combinator_counters* census, bitstream* 
  *                if the function returns a negative value then '*allocation == NULL'
  */
 int32_t decodeMallocWitnessData(void** allocation, bitstring* witness, bitstream* stream) {
+  *allocation = NULL;
   int32_t witnessLen = getBit(stream);
   if (witnessLen < 0) return witnessLen;
   if (0 < witnessLen) witnessLen = decodeUptoMaxInt(stream);

--- a/C/test.c
+++ b/C/test.c
@@ -53,10 +53,10 @@ static void test_decodeUptoMaxInt(void) {
 
 static void test_hashBlock(void) {
   printf("Test hashBlock\n");
-  dag_node* dag = NULL;
+  dag_node* dag;
   combinator_counters census;
   int32_t len, err = 0;
-  void* witnessAlloc;
+  void* witnessAlloc = NULL;
   bitstring witness;
   {
     FILE* file = fmemopen_rb(hashBlock, sizeof_hashBlock);
@@ -133,9 +133,8 @@ static void test_hashBlock(void) {
         failures++;
         printf("Unexpected failure of hashblock evaluation\n");
       }
-
-      free(type_dag);
     }
+    free(type_dag);
   }
   free(dag);
   free(witnessAlloc);
@@ -143,10 +142,10 @@ static void test_hashBlock(void) {
 
 static void test_program(char* name, FILE* file, bool expectedResult, const uint32_t* expectedCMR, const uint32_t* expectedWMR) {
   printf("Test %s\n", name);
-  dag_node* dag = NULL;
+  dag_node* dag;
   combinator_counters census;
   int32_t len, err = 0;
-  void* witnessAlloc;
+  void* witnessAlloc = NULL;
   bitstring witness;
   {
     bitstream stream = initializeBitstream(file);
@@ -181,7 +180,6 @@ static void test_program(char* name, FILE* file, bool expectedResult, const uint
         sourceIx != 0 || targetIx != 0) {
       failures++;
       printf("Unexpected failure of type inference.\n");
-      return;
     } else if (!fillWitnessData(dag, type_dag, (size_t)len, witness)) {
       failures++;
       printf("Unexpected failure of fillWitnessData.\n");
@@ -214,8 +212,8 @@ static void test_occursCheck(void) {
   printf("Test occursCheck\n");
   /* The untyped Simplicity term (case (drop iden) iden) ought to cause an occurs check failure. */
   const unsigned char buf[] = { 0xc1, 0x07, 0x20, 0x30 };
-  dag_node* dag = NULL;
-  combinator_counters census = {0};
+  dag_node* dag;
+  combinator_counters census;
   int32_t len;
   {
     FILE* file = fmemopen_rb(buf, sizeof(buf));

--- a/C/typeInference.c
+++ b/C/typeInference.c
@@ -600,6 +600,7 @@ static bool freezeTypes(type* type_dag, size_t* sourceIx, size_t* targetIx,
  */
 bool mallocTypeInference(type** type_dag, size_t *sourceIx, size_t *targetIx,
                          dag_node* dag, const size_t len, const combinator_counters* census) {
+  *type_dag = NULL;
   /* :TODO: static assert that MAX_DAG size is small enough that these sizes fit within SIZE_T. */
   /* These arrays could be allocated on the stack, but they are potentially large, so we allocate them on the heap instead. */
   unification_arrow* arrow = len <= SIZE_MAX / sizeof(unification_arrow)


### PR DESCRIPTION
1. All *malloc* functions have post-conditions that claim that the returned pointer is set to NULL if the function fails.
However, 'decodeMallocWitnessData' and 'mallocTypeInference' were not setting pointers to NULL under various failure conditions.

2. In functions that do local heap allocations, we cannot use early returns because we bypass the call to 'free' and leak memory.
'elements_simplicity_execSimplicity' had some early returns that occured after the first heap allocation ('decodeMallocDag').

My manual search of the codebase didn't uncover any further occurences of the above kind of errors.