### PR TITLE
Fix issues with zero sized VLAs

### DIFF
--- a/C/deserialize.c
+++ b/C/deserialize.c
@@ -345,7 +345,7 @@ int32_t decodeMallocDag(dag_node** dag, combinator_counters* census, bitstream* 
   if (dagLen <= 0) return dagLen;
   /* :TODO: a consensus parameter limiting the maximum length of a DAG needs to be enforced here */
   if (PTRDIFF_MAX / sizeof(dag_node) < (size_t)dagLen) return ERR_DATA_OUT_OF_RANGE;
-  *dag = malloc(sizeof(dag_node[dagLen]));
+  *dag = malloc((size_t)dagLen * sizeof(dag_node));
   if (!*dag) return ERR_MALLOC;
 
   if (census) *census = (combinator_counters){0};

--- a/C/primitive.h
+++ b/C/primitive.h
@@ -7,21 +7,23 @@
 #include "typeInference.h"
 
 /* Allocate a fresh set of unification variables bound to at least all the types necessary
- * for all the jets that can be created by 'decodeJet', and also the type 'TWO^256'.
+ * for all the jets that can be created by 'decodeJet', and also the type 'TWO^256',
+ * and also allocate space for 'extra_var_len' many unification variables.
  * Return the number of non-trivial bindings created.
  *
  * However, if malloc fails, then return 0.
  *
  * Precondition: NULL != bound_var;
  *               NULL != word256_ix;
+ *               NULL != extra_var_start;
  *
  * Postcondition: Either '*bound_var == NULL' and the function returns 0
- *                or 'unification_var (*bound_var)[N]' is an array of fresh unification variables bound to various types
- *                   such that for any 'jet : A |- B' there is some 'i < N' and 'j < N' such that '(*bound_var)[i]' is bound to 'A'
- *                                                                                            and '(*bound_var)[j]' is bound to 'B'
- *                   and, in particular, '*word256_ix < N' and '(*bound_var)[*word256_ix]' is bound the type 'TWO^256'
+ *                or 'unification_var (*bound_var)[*extra_var_start + extra_var_len]' is an array of unification variables
+ *                   such that for any 'jet : A |- B' there is some 'i < *extra_var_start' and 'j < *extra_var_start' such that
+ *                      '(*bound_var)[i]' is bound to 'A' and '(*bound_var)[j]' is bound to 'B'
+ *                   and, '*word256_ix < *extra_var_start' and '(*bound_var)[*word256_ix]' is bound the type 'TWO^256'
  */
-size_t mallocBoundVars(unification_var** bound_var, size_t* word256_ix);
+size_t mallocBoundVars(unification_var** bound_var, size_t* word256_ix, size_t* extra_var_start, size_t extra_var_len);
 
 /* Decode an application specific jet from 'stream' into 'node'.
  * An application specific jet is a jet that is, or includes a primitive node.

--- a/C/primitive/elements/primitive.c
+++ b/C/primitive/elements/primitive.c
@@ -33,10 +33,11 @@ enum TypeNamesForJets {
   sWord256,
   sSWord256,
   sWord32,
+  word2TimesWord256,
   twoPlusWord4,
-  pubKeyPlusBitPlusWord4,
-  sPubKeyPlusBitPlusWord4,
-  sSPubKeyPlusBitPlusWord4,
+  word2TimesWord256PlusTwoPlusWord4,
+  sWord2TimesWord256PlusTwoPlusWord4,
+  sSWord2TimesWord256PlusTwoPlusWord4,
   NumberOfTypeNames
 };
 
@@ -104,14 +105,16 @@ size_t mallocBoundVars(unification_var** bound_var, size_t* word256_ix) {
       .bound = { .kind = SUM,     .arg = { &(*bound_var)[one], &(*bound_var)[sWord256] } } };
   (*bound_var)[sWord32] = (unification_var){ .isBound = true,
       .bound = { .kind = SUM,     .arg = { &(*bound_var)[one], &(*bound_var)[word32] } } };
+  (*bound_var)[word2TimesWord256] = (unification_var){ .isBound = true,
+      .bound = { .kind = PRODUCT, .arg = { &(*bound_var)[word2], &(*bound_var)[word256] } } };
   (*bound_var)[twoPlusWord4] = (unification_var){ .isBound = true,
       .bound = { .kind = SUM,     .arg = { &(*bound_var)[two], &(*bound_var)[word4] } } };
-  (*bound_var)[pubKeyPlusBitPlusWord4] = (unification_var){ .isBound = true,
-      .bound = { .kind = SUM,     .arg = { &(*bound_var)[pubkey], &(*bound_var)[twoPlusWord4] } } };
-  (*bound_var)[sPubKeyPlusBitPlusWord4] = (unification_var){ .isBound = true,
-      .bound = { .kind = SUM,     .arg = { &(*bound_var)[one], &(*bound_var)[pubKeyPlusBitPlusWord4] } } };
-  (*bound_var)[sSPubKeyPlusBitPlusWord4] = (unification_var){ .isBound = true,
-      .bound = { .kind = SUM,     .arg = { &(*bound_var)[one], &(*bound_var)[sPubKeyPlusBitPlusWord4] } } };
+  (*bound_var)[word2TimesWord256PlusTwoPlusWord4] = (unification_var){ .isBound = true,
+      .bound = { .kind = SUM, .arg = { &(*bound_var)[word2TimesWord256], &(*bound_var)[twoPlusWord4] } } };
+  (*bound_var)[sWord2TimesWord256PlusTwoPlusWord4] = (unification_var){ .isBound = true,
+      .bound = { .kind = SUM,     .arg = { &(*bound_var)[one], &(*bound_var)[word2TimesWord256PlusTwoPlusWord4] } } };
+  (*bound_var)[sSWord2TimesWord256PlusTwoPlusWord4] = (unification_var){ .isBound = true,
+      .bound = { .kind = SUM,     .arg = { &(*bound_var)[one], &(*bound_var)[sWord2TimesWord256PlusTwoPlusWord4] } } };
 
   *word256_ix = word256;
 
@@ -334,7 +337,7 @@ static dag_node jetNode(jetName name) {
       { .tag = JET
       , .jet = outputNullDatum
       , .sourceIx = word64
-      , .targetIx = sSPubKeyPlusBitPlusWord4
+      , .targetIx = sSWord2TimesWord256PlusTwoPlusWord4
       },
    [SCRIPTCMR] =
       { .tag = JET

--- a/C/typeInference.c
+++ b/C/typeInference.c
@@ -605,17 +605,13 @@ bool mallocTypeInference(type** type_dag, size_t *sourceIx, size_t *targetIx,
   unification_arrow* arrow = len <= SIZE_MAX / sizeof(unification_arrow)
                            ? malloc(len * sizeof(unification_arrow))
                            : NULL;
-  /* :TODO: handle the case when max_extra_vars(census) = 0 */
-  unification_var* extra_var = max_extra_vars(census) <= SIZE_MAX / sizeof(unification_var)
-                             ? malloc(max_extra_vars(census) * sizeof(unification_var))
-                             : NULL;
   unification_var* bound_var;
-  size_t word256_ix;
-  size_t bindings_used = mallocBoundVars(&bound_var, &word256_ix);
+  size_t word256_ix, extra_var_start;
+  size_t bindings_used = mallocBoundVars(&bound_var, &word256_ix, &extra_var_start, max_extra_vars(census));
 
-  bool result = arrow && extra_var && bound_var;
+  bool result = arrow && bound_var;
   if (result) {
-    if (typeInference(arrow, dag, len, extra_var, bound_var, word256_ix, &bindings_used)) {
+    if (typeInference(arrow, dag, len, bound_var + extra_var_start, bound_var, word256_ix, &bindings_used)) {
       /* :TODO: constrain the root of the dag to be a Simplicity program: ONE |- ONE */
 
       /* :TODO: static assert that MAX_DAG size is small enough that this size fits within SIZE_T. */
@@ -633,7 +629,6 @@ bool mallocTypeInference(type** type_dag, size_t *sourceIx, size_t *targetIx,
   }
 
   free(arrow);
-  free(extra_var);
   free(bound_var);
   return result;
 }


### PR DESCRIPTION
To address issue https://github.com/ElementsProject/simplicity/issues/25 we begin our removal of VLAs starting with all VLAs used in `sizeof`.

We also fix an issue with possible zero sized allocations for 'extra_var' within `mallocTypeInference`.