### PR TITLE
Avoid calling exit for unimplemented functionality.

### DIFF
--- a/C/deserialize.c
+++ b/C/deserialize.c
@@ -345,7 +345,7 @@ int32_t decodeMallocDag(dag_node** dag, combinator_counters* census, bitstream* 
   if (dagLen <= 0) return dagLen;
   /* :TODO: a consensus parameter limiting the maximum length of a DAG needs to be enforced here */
   if (PTRDIFF_MAX / sizeof(dag_node) < (size_t)dagLen) return ERR_DATA_OUT_OF_RANGE;
-  *dag = malloc(sizeof(dag_node[dagLen]));
+  *dag = malloc((size_t)dagLen * sizeof(dag_node));
   if (!*dag) return ERR_MALLOC;
 
   if (census) *census = (combinator_counters){0};

--- a/C/deserialize.c
+++ b/C/deserialize.c
@@ -220,7 +220,7 @@ static int32_t decodeNode(dag_node* dag, size_t i, bitstream* stream) {
     if (bit) {
       // TODO: Decode jets
       fprintf(stderr, "jets nodes not yet implemented\n");
-      exit(EXIT_FAILURE);
+      return ERR_NOT_YET_IMPLEMENTED;
     } else {
       return decodeJet(&dag[i], stream);
     }

--- a/C/errorCodes.h
+++ b/C/errorCodes.h
@@ -11,6 +11,7 @@
 #define ERR_BITSTREAM_EOF (-2)
 #define ERR_BITSTREAM_ERROR (-3)
 #define ERR_DATA_OUT_OF_RANGE (-4)
+#define ERR_NOT_YET_IMPLEMENTED (-5)
 #define ERR_FAIL_CODE (-6)
 #define ERR_STOP_CODE (-8)
 #define ERR_HIDDEN (-10)

--- a/C/eval.c
+++ b/C/eval.c
@@ -570,8 +570,8 @@ static bool computeEvalTCOBound(memBound *dag_bound, const dag_node* dag, const 
      case DISCONNECT:
       /* :TODO: Support disconnect */
       fprintf(stderr, "EvalTCOBounds for disconnect not yet implemented\n");
-      exit(EXIT_FAILURE);
-      break;
+      free(bound);
+      return false;
      case COMP:
       /* :TODO: replace this check with a consensus critical limit. */
       if (UWORD_BIT - 1 <= SIZE_MAX - type_dag[dag[i].typeAnnotation[1]].bitSize) {

--- a/C/eval.c
+++ b/C/eval.c
@@ -691,9 +691,6 @@ bool evalTCOExpression( bool *evalSuccess, UWORD* output, size_t outputSize, con
 
     *evalSuccess = runTCO(state, stack, dag, type_dag, len, env);
 
-    assert(!*evalSuccess || state.activeReadFrame == frames);
-    assert(!*evalSuccess || state.activeWriteFrame == frames + (stackBound - 1));
-
     if (*evalSuccess && output) {
       memcpy(output, state.activeWriteFrame->edge, roundUWord(outputSize) * sizeof(UWORD));
     }

--- a/C/eval.h
+++ b/C/eval.h
@@ -42,6 +42,7 @@ bool evalTCOExpression( bool *evalSuccess, UWORD* output, size_t outputSize, con
  *
  * Precondition: NULL != evalSuccess
  *               dag_node dag[len] and 'dag' is well-typed with 'type_dag' of type 1 |- 1;
+ *               if 'dag[len]' represents a Simplicity expression with primitives then 'NULL != env';
  */
 static inline bool evalTCOProgram(bool *evalSuccess, const dag_node* dag, type* type_dag, size_t len, const txEnv* env) {
   return evalTCOExpression(evalSuccess, NULL, 0, NULL, 0, dag, type_dag, len, env);

--- a/C/primitive.h
+++ b/C/primitive.h
@@ -7,21 +7,23 @@
 #include "typeInference.h"
 
 /* Allocate a fresh set of unification variables bound to at least all the types necessary
- * for all the jets that can be created by 'decodeJet', and also the type 'TWO^256'.
+ * for all the jets that can be created by 'decodeJet', and also the type 'TWO^256',
+ * and also allocate space for 'extra_var_len' many unification variables.
  * Return the number of non-trivial bindings created.
  *
  * However, if malloc fails, then return 0.
  *
  * Precondition: NULL != bound_var;
  *               NULL != word256_ix;
+ *               NULL != extra_var_start;
  *
  * Postcondition: Either '*bound_var == NULL' and the function returns 0
- *                or 'unification_var (*bound_var)[N]' is an array of fresh unification variables bound to various types
- *                   such that for any 'jet : A |- B' there is some 'i < N' and 'j < N' such that '(*bound_var)[i]' is bound to 'A'
- *                                                                                            and '(*bound_var)[j]' is bound to 'B'
- *                   and, in particular, '*word256_ix < N' and '(*bound_var)[*word256_ix]' is bound the type 'TWO^256'
+ *                or 'unification_var (*bound_var)[*extra_var_start + extra_var_len]' is an array of unification variables
+ *                   such that for any 'jet : A |- B' there is some 'i < *extra_var_start' and 'j < *extra_var_start' such that
+ *                      '(*bound_var)[i]' is bound to 'A' and '(*bound_var)[j]' is bound to 'B'
+ *                   and, '*word256_ix < *extra_var_start' and '(*bound_var)[*word256_ix]' is bound the type 'TWO^256'
  */
-size_t mallocBoundVars(unification_var** bound_var, size_t* word256_ix);
+size_t mallocBoundVars(unification_var** bound_var, size_t* word256_ix, size_t* extra_var_start, size_t extra_var_len);
 
 /* Decode an application specific jet from 'stream' into 'node'.
  * An application specific jet is a jet that is, or includes a primitive node.

--- a/C/primitive/elements/primitive.c
+++ b/C/primitive/elements/primitive.c
@@ -33,10 +33,11 @@ enum TypeNamesForJets {
   sWord256,
   sSWord256,
   sWord32,
+  word2TimesWord256,
   twoPlusWord4,
-  pubKeyPlusBitPlusWord4,
-  sPubKeyPlusBitPlusWord4,
-  sSPubKeyPlusBitPlusWord4,
+  word2TimesWord256PlusTwoPlusWord4,
+  sWord2TimesWord256PlusTwoPlusWord4,
+  sSWord2TimesWord256PlusTwoPlusWord4,
   NumberOfTypeNames
 };
 
@@ -104,14 +105,16 @@ size_t mallocBoundVars(unification_var** bound_var, size_t* word256_ix) {
       .bound = { .kind = SUM,     .arg = { &(*bound_var)[one], &(*bound_var)[sWord256] } } };
   (*bound_var)[sWord32] = (unification_var){ .isBound = true,
       .bound = { .kind = SUM,     .arg = { &(*bound_var)[one], &(*bound_var)[word32] } } };
+  (*bound_var)[word2TimesWord256] = (unification_var){ .isBound = true,
+      .bound = { .kind = PRODUCT, .arg = { &(*bound_var)[word2], &(*bound_var)[word256] } } };
   (*bound_var)[twoPlusWord4] = (unification_var){ .isBound = true,
       .bound = { .kind = SUM,     .arg = { &(*bound_var)[two], &(*bound_var)[word4] } } };
-  (*bound_var)[pubKeyPlusBitPlusWord4] = (unification_var){ .isBound = true,
-      .bound = { .kind = SUM,     .arg = { &(*bound_var)[pubkey], &(*bound_var)[twoPlusWord4] } } };
-  (*bound_var)[sPubKeyPlusBitPlusWord4] = (unification_var){ .isBound = true,
-      .bound = { .kind = SUM,     .arg = { &(*bound_var)[one], &(*bound_var)[pubKeyPlusBitPlusWord4] } } };
-  (*bound_var)[sSPubKeyPlusBitPlusWord4] = (unification_var){ .isBound = true,
-      .bound = { .kind = SUM,     .arg = { &(*bound_var)[one], &(*bound_var)[sPubKeyPlusBitPlusWord4] } } };
+  (*bound_var)[word2TimesWord256PlusTwoPlusWord4] = (unification_var){ .isBound = true,
+      .bound = { .kind = SUM, .arg = { &(*bound_var)[word2TimesWord256], &(*bound_var)[twoPlusWord4] } } };
+  (*bound_var)[sWord2TimesWord256PlusTwoPlusWord4] = (unification_var){ .isBound = true,
+      .bound = { .kind = SUM,     .arg = { &(*bound_var)[one], &(*bound_var)[word2TimesWord256PlusTwoPlusWord4] } } };
+  (*bound_var)[sSWord2TimesWord256PlusTwoPlusWord4] = (unification_var){ .isBound = true,
+      .bound = { .kind = SUM,     .arg = { &(*bound_var)[one], &(*bound_var)[sWord2TimesWord256PlusTwoPlusWord4] } } };
 
   *word256_ix = word256;
 
@@ -334,7 +337,7 @@ static dag_node jetNode(jetName name) {
       { .tag = JET
       , .jet = outputNullDatum
       , .sourceIx = word64
-      , .targetIx = sSPubKeyPlusBitPlusWord4
+      , .targetIx = sSWord2TimesWord256PlusTwoPlusWord4
       },
    [SCRIPTCMR] =
       { .tag = JET

--- a/C/typeInference.c
+++ b/C/typeInference.c
@@ -605,17 +605,13 @@ bool mallocTypeInference(type** type_dag, size_t *sourceIx, size_t *targetIx,
   unification_arrow* arrow = len <= SIZE_MAX / sizeof(unification_arrow)
                            ? malloc(len * sizeof(unification_arrow))
                            : NULL;
-  /* :TODO: handle the case when max_extra_vars(census) = 0 */
-  unification_var* extra_var = max_extra_vars(census) <= SIZE_MAX / sizeof(unification_var)
-                             ? malloc(max_extra_vars(census) * sizeof(unification_var))
-                             : NULL;
   unification_var* bound_var;
-  size_t word256_ix;
-  size_t bindings_used = mallocBoundVars(&bound_var, &word256_ix);
+  size_t word256_ix, extra_var_start;
+  size_t bindings_used = mallocBoundVars(&bound_var, &word256_ix, &extra_var_start, max_extra_vars(census));
 
-  bool result = arrow && extra_var && bound_var;
+  bool result = arrow && bound_var;
   if (result) {
-    if (typeInference(arrow, dag, len, extra_var, bound_var, word256_ix, &bindings_used)) {
+    if (typeInference(arrow, dag, len, bound_var + extra_var_start, bound_var, word256_ix, &bindings_used)) {
       /* :TODO: constrain the root of the dag to be a Simplicity program: ONE |- ONE */
 
       /* :TODO: static assert that MAX_DAG size is small enough that this size fits within SIZE_T. */
@@ -633,7 +629,6 @@ bool mallocTypeInference(type** type_dag, size_t *sourceIx, size_t *targetIx,
   }
 
   free(arrow);
-  free(extra_var);
   free(bound_var);
   return result;
 }


### PR DESCRIPTION
gmaxwell asked if we could avoid calling `exit` to aid in program analysis.
While there still is one call to `exit` in `eval.c` it ought to be unreachable.
There is also a call to `exit` in `test.c` if `fmemopen` fails, but I don't even think that is possible.