### PR TITLE
Make initialization of global constants threadsafe

### DIFF
--- a/C/Makefile
+++ b/C/Makefile
@@ -5,7 +5,17 @@ ifneq ($(doCheck), 1)
 CPPFLAGS := $(CPPFLAGS) -DNDEBUG
 endif
 
+ifneq ($(strip $(SINGLE_THREADED)),)
+  # SINGLE_THREADED is non-empty
+  CPPFLAGS := $(CPPFLAGS) -DSINGLE_THREADED
+endif
+
 CFLAGS := -I include
+
+ifeq ($(strip $(SINGLE_THREADED)),)
+  # SINGLE_THREADED is empty
+  LDFLAGS := -pthread
+endif
 
 LDLIBS := -lsha256compression
 
@@ -25,7 +35,7 @@ libElementsSimplicity.a: bitstream.o dag.o deserialize.o eval.o frame.o jets.o j
 	ar rcs $@ $^
 
 test: test.o hashBlock.o schnorr0.o schnorr6.o primitive/elements/checkSigHashAllTx1.o libElementsSimplicity.a
-	$(CC) $^ -o $@ $(LDLIBS)
+	$(CC) $^ -o $@ $(LDFLAGS) $(LDLIBS)
 
 install: libElementsSimplicity.a
 	mkdir -p $(out)/lib

--- a/C/callonce.h
+++ b/C/callonce.h
@@ -1,0 +1,30 @@
+#ifndef CALLONCE_H
+#define CALLONCE_H
+
+#ifdef SINGLE_THREADED
+
+typedef struct { _Bool flag; } once_flag;
+#define ONCE_FLAG_INIT { 0 }
+
+static inline void call_once(once_flag* initialized, void (*initialize)(void)) {
+  if (!initialized->flag) {
+    initialized->flag = 1;
+    initialize();
+  }
+}
+
+#elif defined __STDC_NO_THREADS__
+
+#include <pthread.h>
+
+#define once_flag pthread_once_t
+#define ONCE_FLAG_INIT PTHREAD_ONCE_INIT
+#define call_once pthread_once
+
+#else
+
+#include <threads.h>
+
+#endif
+
+#endif


### PR DESCRIPTION
We use the 'call_once' interface from <threads.h>.

This fixes <https://github.com/ElementsProject/simplicity/issues/33>.

Later we may wish to consider using generated code to initialize these values instead, depending on how many and how large this static data becomes.