### PR TITLE
nix: add full simplicity dev environment via shell.nix

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ This project contains
 Software artifacts can be built using [Nix](https://nixos.org/nix/).
 
 * To build the Haskell project, run `nix-build -A haskell`.
-* To use the Haskell project, try `nix-shell -p "(import ./default.nix {}).haskellPackages.ghcWithPackages (pkgs: [pkgs.Simplicity])"`.
 * To build the Coq project, run `nix-build -A coq`.
+* For a Simplicity-Haskell development environment, type `nix-shell --arg coq false`.
+* Typing `nix-shell` will provide a full C, Coq and Haskell development environment.
 
 ### Building without Nix
 

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,33 @@
+{ haskell ? true
+, coq     ? true
+, c       ? true
+, nixpkgs ? import <nixpkgs> {}
+}:
+let
+  simplicity      = import ./. {};
+  optional        = nixpkgs.lib.optional;
+  mkDerivation    = nixpkgs.stdenv.mkDerivation;
+
+  haskellDrv =
+    let
+      haskellDevTools = pkgs: with pkgs; [cabal-install hlint hasktags];
+      haskellPkgs     = pkgs: simplicity.haskell.buildInputs ++ haskellDevTools pkgs;
+      haskellDevEnv   = simplicity.haskellPackages.ghcWithPackages haskellPkgs;
+    in
+      mkDerivation {
+        name = "haskell-dev-env";
+        buildInputs = [haskellDevEnv];
+      };
+
+  mergePkgs = name: drvs: mkDerivation {
+    inherit name;
+    buildInputs           = builtins.concatMap (p: p.buildInputs) drvs;
+    nativeBuildInputs     = builtins.concatMap (p: p.nativeBuildInputs) drvs;
+    propagatedBuildInputs = builtins.concatMap (p: p.propagatedBuildInputs) drvs;
+  };
+
+  selectedPkgs = optional haskell haskellDrv
+              ++ optional coq     simplicity.coq
+              ++ optional c       simplicity.c;
+in
+  mergePkgs "simplicity-dev-env" selectedPkgs


### PR DESCRIPTION
This adds a full Simplicity development environment using nix-shell,
and adds some docs explaining how to use it.