### PR TITLE
Optimize sha256_uchars using memcpy.

### DIFF
--- a/C/include/simplicity/elements.h
+++ b/C/include/simplicity/elements.h
@@ -13,7 +13,7 @@
 
 /* A type for a Bitcoin script with its length.
  *
- * Invariant: unsigned char code[len]
+ * Invariant: if 0 < len then unsigned char code[len]
  */
 typedef struct rawScript {
   const unsigned char* code;

--- a/C/primitive/elements.c
+++ b/C/primitive/elements.c
@@ -122,7 +122,7 @@ static void sha256_issuance(sha256_context* ctx, const assetIssuance* issuance) 
 /* Compute the SHA-256 hash of a scriptPubKey and write it into 'result'.
  *
  * Precondition: NULL != result;
- *               unsigned char scriptPubKey[scriptLen];
+ *               NULL != scriptPubKey;
  */
 static void hashScriptPubKey(sha256_midstate* result, const rawScript* scriptPubKey) {
   sha256_context ctx = sha256_init(result);


### PR DESCRIPTION
I've also updated/corrected some comments about functions/data that (indirectly) call/passed into sha256_uchars.

This code can be compared with [secp256k1_sha256_write](https://github.com/bitcoin/bitcoin/blob/1dbbfea9cd910f8e658bc1ab0b70dc89ba1313f9/src/secp256k1/src/hash_impl.h#L131-L147).