### PR TITLE
Swap the arguments to the first parameter of disconnect.

### DIFF
--- a/C/typeInference.c
+++ b/C/typeInference.c
@@ -312,7 +312,7 @@ static bool typeInference(unification_arrow* arrow, const dag_node* dag, const s
         }          } };
       APPLY_BINDING(&(arrow[dag[i].child[0]].source), &((binding)
         { .kind = PRODUCT
-        , .arg = { &(arrow[i].source), &(bound_var[word256_ix]) }
+        , .arg = { &(bound_var[word256_ix]), &(arrow[i].source) }
         }));
       APPLY_BINDING(&(arrow[dag[i].child[0]].target), &((binding)
         { .kind = PRODUCT

--- a/Coq/Simplicity/Delegation.v
+++ b/Coq/Simplicity/Delegation.v
@@ -14,7 +14,7 @@ Module Delegation.
 
 Record mixin (term : Ty -> Ty -> Type) := Mixin
 { disconnect : forall {A B C D},
-    term (A * Word256) (B * C) -> term C D -> term A (B * D)
+    term (Word256 * A) (B * C) -> term C D -> term A (B * D)
 }.
 
 Record class (term : Ty -> Ty -> Type) := Class
@@ -37,7 +37,7 @@ Canonical Structure toWitness (alg : Algebra) : Witness.Algebra := Witness.Pack 
 
 Module Combinators.
 
-Definition disconnect {A B C D : Ty} {alg : Algebra} : alg (A * Word256) (B * C) -> alg C D -> alg A (B * D) :=
+Definition disconnect {A B C D : Ty} {alg : Algebra} : alg (Word256 * A) (B * C) -> alg C D -> alg A (B * D) :=
   disconnect (class_of alg).
 
 End Combinators.
@@ -80,7 +80,7 @@ Canonical Structure Delegation.toCore.
 Canonical Structure Delegation.toWitness.
 
 Lemma disconnect_Parametric {alg1 alg2 : Delegation.Algebra} (R : Delegation.Parametric.Rel alg1 alg2)
-  {A B C D} s1 s2 t1 t2 : R (A * Word256) (B * C) s1 s2 -> R C D t1 t2 -> R A (B * D) (disconnect s1 t1) (disconnect s2 t2).
+  {A B C D} s1 s2 t1 t2 : R (Word256 * A) (B * C) s1 s2 -> R C D t1 t2 -> R A (B * D) (disconnect s1 t1) (disconnect s2 t2).
 Proof.
 destruct R as [R [Rb []]].
 cbn; auto.
@@ -217,7 +217,7 @@ Definition WitnessDelegator_mixin (alg : Witness.Algebra) : Witness.mixin (Deleg
 Definition DelegationDelegator_mixin (alg : Core.Algebra) : Delegation.mixin (Delegator alg) :=
   {| Delegation.disconnect A B C D s t :=
      {| delegatorRoot := @disconnect A B C D _ (delegatorRoot s) (delegatorRoot t)
-      ; runDelegator := iden &&& scribe (from_hash256 (delegatorRoot t))
+      ; runDelegator := scribe (from_hash256 (delegatorRoot t)) &&& iden
                     >>> runDelegator s >>> take iden &&& drop (runDelegator t)
       |}
    |}.

--- a/Haskell/Core/Simplicity/MerkleRoot/Impl.hs
+++ b/Haskell/Core/Simplicity/MerkleRoot/Impl.hs
@@ -234,7 +234,7 @@ instance Delegate WitnessRoot where
     result = observe $ compress (compress (compress (witnessTag "disconnect") (typeRootR (reifyProxy proxyA), typeRootR (reifyProxy proxyB)))
                                           (typeRootR (reifyProxy proxyC), typeRootR (reifyProxy proxyD)))
                                 (s, t)
-    proxy :: proxy (a, w) (b, c) -> proxy c d -> (Proxy a, Proxy b, Proxy c, Proxy d)
+    proxy :: proxy (w, a) (b, c) -> proxy c d -> (Proxy a, Proxy b, Proxy c, Proxy d)
     proxy _ _ = (Proxy, Proxy, Proxy, Proxy)
     (proxyA, proxyB, proxyC, proxyD) = proxy ws wt
 

--- a/Haskell/Core/Simplicity/Programs/Loop.hs
+++ b/Haskell/Core/Simplicity/Programs/Loop.hs
@@ -18,7 +18,7 @@ import Simplicity.Ty.Word
 -- Thanks to Haskell's laziness, this is feasable.
 loopBody :: (Assert term, Delegate term, TyC a, TyC b) => term a (Either a b) -> term (a, Word256) b
 loopBody t = take t &&& ih
-         >>> match (disconnect (assert (oih &&& ih >>> eq) &&& oh) (loopBody t) >>> ih) oh
+         >>> match (disconnect (assert (iih &&& oh >>> eq) &&& ih) (loopBody t) >>> ih) oh
 
 -- | Builds an unbounded loop via a self-delegation construction.
 loop :: (Assert term, Delegate term, TyC a, TyC b) => Product CommitmentRoot term a (Either a b) -> Product CommitmentRoot term a b

--- a/Haskell/Core/Simplicity/Term/Core.hs
+++ b/Haskell/Core/Simplicity/Term/Core.hs
@@ -172,7 +172,7 @@ instance Monad m => Witness (Kleisli m) where
 
 -- | This class adds 'disconnect' expressions to the Simplicity language, which can be used for delegation.
 class Delegate term where
-  disconnect :: (TyC a, TyC b, TyC c, TyC d) => term (a, Word256) (b, c) -> term c d -> term a (b, d)
+  disconnect :: (TyC a, TyC b, TyC c, TyC d) => term (Word256, a) (b, c) -> term c d -> term a (b, d)
 
 instance (Core p, Core q) => Core (Product p q) where
   iden = Product iden iden

--- a/Haskell/Indef/Simplicity/Inference.hs
+++ b/Haskell/Indef/Simplicity/Inference.hs
@@ -369,7 +369,7 @@ inference = foldM loop empty
       (c,d) <- termFArrow =<< lookup it
       a <- fresh
       b <- fresh
-      _ <- UTerm (Prod a (unfreeze tyWord256)) =:= aw
+      _ <- UTerm (Prod (unfreeze tyWord256) a) =:= aw
       _ <- UTerm (Prod b c) =:= bc
       return (Disconnect a b c d (fromInteger is) (fromInteger it))
     go (Hidden h) = pure (Hidden h)
@@ -509,7 +509,7 @@ typeCheck s = result
                                                     SomeArrow t <- lookup it
                                                     let (rc1, rd) = reifyArrow t
                                                     case reifyArrow s of
-                                                      ((ProdR ra rw), (ProdR rb rc0)) -> do
+                                                      ((ProdR rw ra), (ProdR rb rc0)) -> do
                                                         Refl <- assertEqualTyReflect rw (reify :: TyReflect Word256)
                                                         Refl <- assertEqualTyReflect rc0 rc1
                                                         return (someArrowR ra (ProdR rb rd) (disconnect s t))

--- a/Haskell/Indef/Simplicity/Semantics.hs
+++ b/Haskell/Indef/Simplicity/Semantics.hs
@@ -69,6 +69,6 @@ instance Core p => Delegate (Delegator p) where
   disconnect ~(Delegator rs fs) ~(Delegator rt ft) = Delegator (disconnect rs rt) f
    where
     root256 = toWord256 . integerHash256 $ commitmentRoot rt
-    f = iden &&& scribe root256 >>> fs >>> take iden &&& drop ft
+    f = scribe root256 &&& iden >>> fs >>> take iden &&& drop ft
 
 instance (Jet p, Witness p) => Simplicity (Delegator p) where

--- a/Simplicity-TR.tm
+++ b/Simplicity-TR.tm
@@ -4104,7 +4104,7 @@
   \;
 
   <\with|par-mode|center>
-    <tabular*|<tformat|<cwith|2|2|1|1|cell-tborder|1pt>|<cwith|2|2|1|1|cell-hyphen|n>|<cwith|1|1|1|1|cell-width|>|<cwith|1|1|1|1|cell-hmode|auto>|<cwith|2|2|1|1|cell-col-span|1>|<table|<row|<cell|<subtable|<tformat|<cwith|1|1|2|2|cell-halign|c>|<cwith|1|1|1|1|cell-halign|c>|<table|<row|<cell|<math|s\<of\>A\<times\><2><rsup|256>\<vdash\>B\<times\>C>>|<cell|<math|t\<of\>C\<vdash\>D>>>>>>>>|<row|<cell|<math|<math-ss|disconnect><rsub|A,B,C,D>
+    <tabular*|<tformat|<cwith|2|2|1|1|cell-tborder|1pt>|<cwith|2|2|1|1|cell-hyphen|n>|<cwith|1|1|1|1|cell-width|>|<cwith|1|1|1|1|cell-hmode|auto>|<cwith|2|2|1|1|cell-col-span|1>|<table|<row|<cell|<subtable|<tformat|<cwith|1|1|2|2|cell-halign|c>|<cwith|1|1|1|1|cell-halign|c>|<table|<row|<cell|<math|s\<of\><2><rsup|256>\<times\>A\<vdash\>B\<times\>C>>|<cell|<math|t\<of\>C\<vdash\>D>>>>>>>>|<row|<cell|<math|<math-ss|disconnect><rsub|A,B,C,D>
     s t\<of\>A\<vdash\>B\<times\>D>>>>>>
   </with>
 
@@ -4119,7 +4119,7 @@
     <around*|\<llbracket\>|<math-ss|disconnect><rsub|A,B,C,D> s
     t|\<rrbracket\>><rsup|\<cal-M\>><around*|(|a|)>\<assign\><around*|\<llbracket\>|s;<math-ss|take>
     <math-ss|iden> \<vartriangle\> <math-ss|drop>
-    t|\<rrbracket\>><rsup|\<cal-M\>><around*|\<langle\>|a,<cmr|t>|\<rangle\>>
+    t|\<rrbracket\>><rsup|\<cal-M\>><around*|\<langle\>|<cmr|t>,a|\<rangle\>>
   </equation*>
 
   Like a <samp|witness> expression, the real significance comes from the form
@@ -4203,8 +4203,8 @@
     t k>>|<cell|:=>|<cell|<math|<math-ss|take> t \<vartriangle\>
     <math-ss|IH>>>>|<row|<cell|>|<cell|;>|<cell|<samp|case>
     <math|<around*|(|<math-ss|disconnect> <around*|(|<math-ss|assert>
-    <around*|(|<math-ss|OIH> \<vartriangle\> <math-ss|IH>
-    ;<math-ss|eq><rsub|<2><rsup|256>>|)> \<vartriangle\> <math-ss|OH>|)> k;
+    <around*|(|<math-ss|IIH> \<vartriangle\> <math-ss|OH>
+    ;<math-ss|eq><rsub|<2><rsup|256>>|)> \<vartriangle\> <math-ss|IH>|)> k;
     <math|<math-ss|IH>>|)>> <math|<math-ss|OH>>>>>>>>>>>>
   </render-code>
 
@@ -4249,48 +4249,48 @@
   <\eqnarray*>
     <tformat|<table|<row|<cell|>|<cell|>|<cell|<around*|\<llbracket\>|<samp|case>
     <math|<around*|(|<math-ss|disconnect> <around*|(|<math-ss|assert>
-    <around*|(|<math-ss|OIH> \<vartriangle\> <math-ss|IH>
-    ;<math-ss|eq><rsub|<2><rsup|256>>|)> \<vartriangle\> <math-ss|OH>|)> k;
+    <around*|(|<math-ss|IIH> \<vartriangle\> <math-ss|OH>
+    ;<math-ss|eq><rsub|<2><rsup|256>>|)> \<vartriangle\> <math-ss|IH>|)> k;
     <math|<math-ss|IH>>|)>> <math|<math-ss|OH>>|\<rrbracket\>><rsup|\<cal-M\>><around*|\<langle\>|<injl|<around*|(|a<rsub|1>|)>>,h|\<rangle\>>>>|<row||<cell|=>|<cell|<around*|\<llbracket\>|<math|<math-ss|disconnect>
-    <around*|(|<math-ss|assert> <around*|(|<math-ss|OIH> \<vartriangle\>
-    <math-ss|IH> ;<math-ss|eq><rsub|<2><rsup|256>>|)> \<vartriangle\>
-    <math-ss|OH>|)> k; <math|<math-ss|IH>>>|\<rrbracket\>><rsup|\<cal-M\>><around*|\<langle\>|a<rsub|1>,h|\<rangle\>>>>|<row|<cell|>|<cell|=>|<cell|<around*|(|<around*|\<llbracket\>|<math|<math-ss|IH>>|\<rrbracket\>><rsup|\<cal-M\>>\<leftarrowtail\><around*|\<llbracket\>|<math|<math-ss|disconnect>
-    <around*|(|<math-ss|assert> <around*|(|<math-ss|OIH> \<vartriangle\>
-    <math-ss|IH> ;<math-ss|eq><rsub|<2><rsup|256>>|)> \<vartriangle\>
-    <math-ss|OH>|)> k>|\<rrbracket\>><rsup|\<cal-M\>>|)><around*|\<langle\>|a<rsub|1>,h|\<rangle\>>>>|<row|<cell|>|<cell|=>|<cell|<around*|(|<around*|\<llbracket\>|<math|<math-ss|IH>>|\<rrbracket\>><rsup|\<cal-M\>>\<leftarrowtail\><around*|\<llbracket\>|<math-ss|assert>
-    <around*|(|<math-ss|OIH> \<vartriangle\> <math-ss|IH>
+    <around*|(|<math-ss|assert> <around*|(|<math-ss|IIH> \<vartriangle\>
+    <math-ss|OH> ;<math-ss|eq><rsub|<2><rsup|256>>|)> \<vartriangle\>
+    <math-ss|IH>|)> k; <math|<math-ss|IH>>>|\<rrbracket\>><rsup|\<cal-M\>><around*|\<langle\>|a<rsub|1>,h|\<rangle\>>>>|<row|<cell|>|<cell|=>|<cell|<around*|(|<around*|\<llbracket\>|<math|<math-ss|IH>>|\<rrbracket\>><rsup|\<cal-M\>>\<leftarrowtail\><around*|\<llbracket\>|<math|<math-ss|disconnect>
+    <around*|(|<math-ss|assert> <around*|(|<math-ss|IIH> \<vartriangle\>
+    <math-ss|OH> ;<math-ss|eq><rsub|<2><rsup|256>>|)> \<vartriangle\>
+    <math-ss|IH>|)> k>|\<rrbracket\>><rsup|\<cal-M\>>|)><around*|\<langle\>|a<rsub|1>,h|\<rangle\>>>>|<row|<cell|>|<cell|=>|<cell|<around*|(|<around*|\<llbracket\>|<math|<math-ss|IH>>|\<rrbracket\>><rsup|\<cal-M\>>\<leftarrowtail\><around*|\<llbracket\>|<math-ss|assert>
+    <around*|(|<math-ss|IIH> \<vartriangle\> <math-ss|OH>
     ;<math-ss|eq><rsub|<2><rsup|256>>|)> \<vartriangle\>
-    <math-ss|OH>;<math-ss|take> <math-ss|iden> \<vartriangle\> <math-ss|drop>
-    k|\<rrbracket\>><rsup|\<cal-M\>>|)><around*|\<langle\>|<around*|\<langle\>|a<rsub|1>,h|\<rangle\>>,<cmr|k>|\<rangle\>>>>|<row|<cell|>|<cell|=>|<cell|<around*|(|<around*|\<llbracket\>|<math|<math-ss|IH>>|\<rrbracket\>><rsup|\<cal-M\>>\<leftarrowtail\><around*|\<llbracket\>|<math-ss|take>
+    <math-ss|IH>;<math-ss|take> <math-ss|iden> \<vartriangle\> <math-ss|drop>
+    k|\<rrbracket\>><rsup|\<cal-M\>>|)><around*|\<langle\>|<cmr|k>,<around*|\<langle\>|a<rsub|1>,h|\<rangle\>>|\<rangle\>>>>|<row|<cell|>|<cell|=>|<cell|<around*|(|<around*|\<llbracket\>|<math|<math-ss|IH>>|\<rrbracket\>><rsup|\<cal-M\>>\<leftarrowtail\><around*|\<llbracket\>|<math-ss|take>
     <math-ss|iden> \<vartriangle\> <math-ss|drop>
     k|\<rrbracket\>><rsup|\<cal-M\>>\<leftarrowtail\><around*|\<llbracket\>|<math-ss|assert>
-    <around*|(|<math-ss|OIH> \<vartriangle\> <math-ss|IH>
+    <around*|(|<math-ss|IIH> \<vartriangle\> <math-ss|OH>
     ;<math-ss|eq><rsub|<2><rsup|256>>|)> \<vartriangle\>
-    <math-ss|OH>|\<rrbracket\>><rsup|\<cal-M\>>|)><around*|\<langle\>|<around*|\<langle\>|a<rsub|1>,h|\<rangle\>>,<cmr|k>|\<rangle\>>>>|<row|<cell|>|<cell|=>|<cell|<around*|(|<around*|\<llbracket\>|<math-ss|take>
+    <math-ss|IH>|\<rrbracket\>><rsup|\<cal-M\>>|)><around*|\<langle\>|<cmr|k>,<around*|\<langle\>|a<rsub|1>,h|\<rangle\>>|\<rangle\>>>>|<row|<cell|>|<cell|=>|<cell|<around*|(|<around*|\<llbracket\>|<math-ss|take>
     <math-ss|iden> \<vartriangle\> <math-ss|drop>
     k;<math-ss|IH>|\<rrbracket\>><rsup|\<cal-M\>>\<leftarrowtail\><around*|\<llbracket\>|<math-ss|assert>
-    <around*|(|<math-ss|OIH> \<vartriangle\> <math-ss|IH>
+    <around*|(|<math-ss|IIH> \<vartriangle\> <math-ss|OH>
     ;<math-ss|eq><rsub|<2><rsup|256>>|)> \<vartriangle\>
-    <math-ss|OH>|\<rrbracket\>><rsup|\<cal-M\>>|)><around*|\<langle\>|<around*|\<langle\>|a<rsub|1>,h|\<rangle\>>,<cmr|k>|\<rangle\>>>>|<row|<cell|>|<cell|=>|<cell|<around*|(|<around*|\<llbracket\>|<math-ss|drop>
+    <math-ss|IH>|\<rrbracket\>><rsup|\<cal-M\>>|)><around*|\<langle\>|<cmr|k>,<around*|\<langle\>|a<rsub|1>,h|\<rangle\>>|\<rangle\>>>>|<row|<cell|>|<cell|=>|<cell|<around*|(|<around*|\<llbracket\>|<math-ss|drop>
     k|\<rrbracket\>><rsup|\<cal-M\>>\<leftarrowtail\><around*|\<llbracket\>|<math-ss|assert>
-    <around*|(|<math-ss|OIH> \<vartriangle\> <math-ss|IH>
+    <around*|(|<math-ss|IIH> \<vartriangle\> <math-ss|OH>
     ;<math-ss|eq><rsub|<2><rsup|256>>|)> \<vartriangle\>
-    <math-ss|OH>|\<rrbracket\>><rsup|\<cal-M\>>|)><around*|\<langle\>|<around*|\<langle\>|a<rsub|1>,h|\<rangle\>>,<cmr|k>|\<rangle\>>>>>>
+    <math-ss|IH>|\<rrbracket\>><rsup|\<cal-M\>>|)><around*|\<langle\>|<cmr|k>,<around*|\<langle\>|a<rsub|1>,h|\<rangle\>>|\<rangle\>>>>>>
   </eqnarray*>
 
   For the first part we have
 
   <\eqnarray*>
     <tformat|<table|<row|<cell|>|<cell|>|<cell|<around*|\<llbracket\>|<math-ss|assert>
-    <around*|(|<math-ss|OIH> \<vartriangle\> <math-ss|IH>
+    <around*|(|<math-ss|IIH> \<vartriangle\> <math-ss|OH>
     ;<math-ss|eq><rsub|<2><rsup|256>>|)> \<vartriangle\>
-    <math-ss|OH>|\<rrbracket\>><rsup|\<cal-M\>><around*|\<langle\>|<around*|\<langle\>|a<rsub|1>,h|\<rangle\>>,<cmr|k>|\<rangle\>>>>|<row|<cell|>|<cell|=>|<cell|\<iota\><rsup|\<cal-M\>><rsub|<maybe>><around*|(|<around*|\<llbracket\>|<math-ss|assert>
-    <around*|(|<math-ss|OIH> \<vartriangle\> <math-ss|IH>
+    <math-ss|IH>|\<rrbracket\>><rsup|\<cal-M\>><around*|\<langle\>|<cmr|k>,<around*|\<langle\>|a<rsub|1>,h|\<rangle\>>|\<rangle\>>>>|<row|<cell|>|<cell|=>|<cell|\<iota\><rsup|\<cal-M\>><rsub|<maybe>><around*|(|<around*|\<llbracket\>|<math-ss|assert>
+    <around*|(|<math-ss|IIH> \<vartriangle\> <math-ss|OH>
     ;<math-ss|eq><rsub|<2><rsup|256>>|)> \<vartriangle\>
-    <math-ss|OH>|\<rrbracket\>><rsup|<maybe>><around*|\<langle\>|<around*|\<langle\>|a<rsub|1>,h|\<rangle\>>,<cmr|k>|\<rangle\>>|)>>>|<row|<cell|>|<cell|=>|<cell|\<iota\><rsup|\<cal-M\>><rsub|<maybe>><around*|(|\<phi\><rsup|<maybe>><around*|\<langle\>|<around*|\<llbracket\>|<math-ss|assert>
-    <around*|(|<math-ss|OIH> \<vartriangle\> <math-ss|IH>
-    ;<math-ss|eq><rsub|<2><rsup|256>>|)>|\<rrbracket\>><rsup|<maybe>><around*|\<langle\>|<around*|\<langle\>|a<rsub|1>,h|\<rangle\>>,<cmr|k>|\<rangle\>>,\<eta\><rsup|S><around*|\<langle\>|a<rsub|1>,h|\<rangle\>>|\<rangle\>>|)>>>|<row|<cell|>|<cell|=>|<cell|\<iota\><rsup|\<cal-M\>><rsub|<maybe>><around*|(|\<phi\><rsup|<maybe>><around*|\<langle\>|<around*|\<llbracket\>|<math-ss|OIH>
-    \<vartriangle\> <math-ss|IH> ;<math-ss|eq><rsub|<2><rsup|256>>|\<rrbracket\>><around*|\<langle\>|<around*|\<langle\>|a<rsub|1>,h|\<rangle\>>,<cmr|k>|\<rangle\>>,\<eta\><rsup|S><around*|\<langle\>|a<rsub|1>,h|\<rangle\>>|\<rangle\>>|)>>>|<row|<cell|>|<cell|=>|<cell|\<iota\><rsup|\<cal-M\>><rsub|<maybe>><around*|(|\<phi\><rsup|<maybe>><around*|\<langle\>|<around*|\<llbracket\>|<math-ss|eq><rsub|<2><rsup|256>>|\<rrbracket\>><around*|\<langle\>|h,<cmr|k>|\<rangle\>>,\<eta\><rsup|S><around*|\<langle\>|a<rsub|1>,h|\<rangle\>>|\<rangle\>>|)>>>>>
+    <math-ss|IH>|\<rrbracket\>><rsup|<maybe>><around*|\<langle\>|<cmr|k>,<around*|\<langle\>|a<rsub|1>,h|\<rangle\>>|\<rangle\>>|)>>>|<row|<cell|>|<cell|=>|<cell|\<iota\><rsup|\<cal-M\>><rsub|<maybe>><around*|(|\<phi\><rsup|<maybe>><around*|\<langle\>|<around*|\<llbracket\>|<math-ss|assert>
+    <around*|(|<math-ss|IIH> \<vartriangle\> <math-ss|OH>
+    ;<math-ss|eq><rsub|<2><rsup|256>>|)>|\<rrbracket\>><rsup|<maybe>><around*|\<langle\>|<cmr|k>,<around*|\<langle\>|a<rsub|1>,h|\<rangle\>>|\<rangle\>>,\<eta\><rsup|S><around*|\<langle\>|a<rsub|1>,h|\<rangle\>>|\<rangle\>>|)>>>|<row|<cell|>|<cell|=>|<cell|\<iota\><rsup|\<cal-M\>><rsub|<maybe>><around*|(|\<phi\><rsup|<maybe>><around*|\<langle\>|<around*|\<llbracket\>|<math-ss|IIH>
+    \<vartriangle\> <math-ss|OH> ;<math-ss|eq><rsub|<2><rsup|256>>|\<rrbracket\>><around*|\<langle\>|<cmr|k>,<around*|\<langle\>|a<rsub|1>,h|\<rangle\>>|\<rangle\>>,\<eta\><rsup|S><around*|\<langle\>|a<rsub|1>,h|\<rangle\>>|\<rangle\>>|)>>>|<row|<cell|>|<cell|=>|<cell|\<iota\><rsup|\<cal-M\>><rsub|<maybe>><around*|(|\<phi\><rsup|<maybe>><around*|\<langle\>|<around*|\<llbracket\>|<math-ss|eq><rsub|<2><rsup|256>>|\<rrbracket\>><around*|\<langle\>|h,<cmr|k>|\<rangle\>>,\<eta\><rsup|S><around*|\<langle\>|a<rsub|1>,h|\<rangle\>>|\<rangle\>>|)>>>>>
   </eqnarray*>
 
   We know that <math|<around*|\<llbracket\>|<math-ss|eq><rsub|<2><rsup|256>>|\<rrbracket\>><around*|\<langle\>|h,<cmr|k>|\<rangle\>>=<math-tt|1><rsub|<2>>=\<eta\><rsup|S><around*|\<langle\>||\<rangle\>>>
@@ -4299,9 +4299,9 @@
   if and only if <math|h\<neq\><cmr|k>>. When <math|h\<neq\><cmr|k>>, then
 
   <\equation*>
-    <around*|\<llbracket\>|<math-ss|assert> <around*|(|<math-ss|OIH>
-    \<vartriangle\> <math-ss|IH> ;<math-ss|eq><rsub|<2><rsup|256>>|)>
-    \<vartriangle\> <math-ss|OH>|\<rrbracket\>><rsup|\<cal-M\>><around*|\<langle\>|<around*|\<langle\>|a<rsub|1>,h|\<rangle\>>,<cmr|k>|\<rangle\>>=\<emptyset\><rsup|\<cal-M\>>
+    <around*|\<llbracket\>|<math-ss|assert> <around*|(|<math-ss|IIH>
+    \<vartriangle\> <math-ss|OH> ;<math-ss|eq><rsub|<2><rsup|256>>|)>
+    \<vartriangle\> <math-ss|IH>|\<rrbracket\>><rsup|\<cal-M\>><around*|\<langle\>|<around*|\<langle\>|a<rsub|1>,h|\<rangle\>>,<cmr|k>|\<rangle\>>=\<emptyset\><rsup|\<cal-M\>>
   </equation*>
 
   and the whole <samp|loopBody> expression fails with a
@@ -4309,9 +4309,9 @@
   <math|h=<cmr|k>> we have that
 
   <\equation*>
-    <around*|\<llbracket\>|<math-ss|assert> <around*|(|<math-ss|OIH>
-    \<vartriangle\> <math-ss|IH> ;<math-ss|eq><rsub|<2><rsup|256>>|)>
-    \<vartriangle\> <math-ss|OH>|\<rrbracket\>><rsup|\<cal-M\>><around*|\<langle\>|<around*|\<langle\>|a<rsub|1>,h|\<rangle\>>,<cmr|k>|\<rangle\>>=\<eta\><rsup|\<cal-M\>><around*|\<langle\>|<around*|\<langle\>||\<rangle\>>,<around*|\<langle\>|a<rsub|1>,h|\<rangle\>>|\<rangle\>>
+    <around*|\<llbracket\>|<math-ss|assert> <around*|(|<math-ss|IIH>
+    \<vartriangle\> <math-ss|OH> ;<math-ss|eq><rsub|<2><rsup|256>>|)>
+    \<vartriangle\> <math-ss|IH>|\<rrbracket\>><rsup|\<cal-M\>><around*|\<langle\>|<around*|\<langle\>|a<rsub|1>,h|\<rangle\>>,<cmr|k>|\<rangle\>>=\<eta\><rsup|\<cal-M\>><around*|\<langle\>|<around*|\<langle\>||\<rangle\>>,<around*|\<langle\>|a<rsub|1>,h|\<rangle\>>|\<rangle\>>
   </equation*>
 
   and we can continue with
@@ -4325,9 +4325,9 @@
 
   <\equation*>
     <around*|\<llbracket\>|<samp|case> <math|<around*|(|<math-ss|disconnect>
-    <around*|(|<math-ss|assert> <around*|(|<math-ss|OIH> \<vartriangle\>
-    <math-ss|IH> ;<math-ss|eq><rsub|<2><rsup|256>>|)> \<vartriangle\>
-    <math-ss|OH>|)> k; <math|<math-ss|IH>>|)>>
+    <around*|(|<math-ss|assert> <around*|(|<math-ss|IIH> \<vartriangle\>
+    <math-ss|OH> ;<math-ss|eq><rsub|<2><rsup|256>>|)> \<vartriangle\>
+    <math-ss|IH>|)> k; <math|<math-ss|IH>>|)>>
     <math|<math-ss|OH>>|\<rrbracket\>><rsup|\<cal-M\>><around*|\<langle\>|<injl|<around*|(|a<rsub|1>|)>>,h|\<rangle\>>=<around*|\<llbracket\>|k|\<rrbracket\>><rsup|\<cal-M\>><around*|\<langle\>|a<rsub|1>,h|\<rangle\>><text|.>
   </equation*>
 
@@ -4365,9 +4365,9 @@
       <tformat|<table|<row|<cell|loopTail>|<cell|\<assign\>>|<cell|SHA256<rsub|Block><around*|\<langle\>|tag<rsup|c><rsub|<math-ss|comp>>\<comma\>
       <around*|\<langle\>|SHA256<rsub|Block><around*|\<langle\>|tag<rsup|c><rsub|<math-ss|disconnect>>\<comma\>
       <around*|\<langle\>|<around*|\<lfloor\>|0|\<rfloor\>><rsub|256>,<cmr|<math-ss|assert>
-      <around*|(|<math-ss|OIH> \<vartriangle\> <math-ss|IH>
+      <around*|(|<math-ss|IIH> \<vartriangle\> <math-ss|OH>
       ;<math-ss|eq><rsub|<2><rsup|256>>|)> \<vartriangle\>
-      <math-ss|OH>>|\<rangle\>>|\<rangle\>>,<cmr|<math-ss|IH>>|\<rangle\>>|\<rangle\>><text|.>>>>>
+      <math-ss|IH>>|\<rangle\>>|\<rangle\>>,<cmr|<math-ss|IH>>|\<rangle\>>|\<rangle\>><text|.>>>>>
     </eqnarray*>
   </lemma>
 
@@ -8288,8 +8288,8 @@
       Full Simplicity <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-150>>
 
-      <with|par-left|<quote|1tab>|9.2.4<space|2spc>Known Discounted Jets
-      <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
+      <with|par-left|<quote|1tab>|9.2.4<space|2spc><with|font-family|<quote|tt>|language|<quote|verbatim>|JetType>
+      class <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-151>>
 
       <with|par-left|<quote|1tab>|9.2.5<space|2spc>Type Inference
@@ -8320,45 +8320,49 @@
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
       <no-break><pageref|auto-158>>
 
+      <with|par-left|<quote|1tab>|9.4.2<space|2spc>Known Discounted Jets
+      <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
+      <no-break><pageref|auto-159>>
+
       9.5<space|2spc>Simplicity <with|font-family|<quote|tt>|language|<quote|verbatim>|testsuite>
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
-      <no-break><pageref|auto-159>
+      <no-break><pageref|auto-160>
 
       <vspace*|1fn><with|font-series|<quote|bold>|math-font-series|<quote|bold>|10<space|2spc>C
       Library Guide> <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
-      <no-break><pageref|auto-160><vspace|0.5fn>
+      <no-break><pageref|auto-161><vspace|0.5fn>
 
       <vspace*|1fn><with|font-series|<quote|bold>|math-font-series|<quote|bold>|Appendix
       A<space|2spc>Elements Application> <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
-      <no-break><pageref|auto-161><vspace|0.5fn>
+      <no-break><pageref|auto-162><vspace|0.5fn>
 
       A.1<space|2spc>Denotational Semantics
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
-      <no-break><pageref|auto-162>
+      <no-break><pageref|auto-163>
 
       <with|par-left|<quote|1tab>|A.1.1<space|2spc>Null Data
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
-      <no-break><pageref|auto-163>>
+      <no-break><pageref|auto-164>>
 
       <with|par-left|<quote|1tab>|A.1.2<space|2spc>Merkle Roots
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
-      <no-break><pageref|auto-164>>
+      <no-break><pageref|auto-165>>
 
       <with|par-left|<quote|1tab>|A.1.3<space|2spc>Serialization
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
-      <no-break><pageref|auto-165>>
+      <no-break><pageref|auto-166>>
 
       A.2<space|2spc>Jets <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
-      <no-break><pageref|auto-166>
+      <no-break><pageref|auto-167>
 
       <vspace*|1fn><with|font-series|<quote|bold>|math-font-series|<quote|bold>|Appendix
       B<space|2spc>Alternative Serialization of Simplicity DAGs>
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
-      <no-break><pageref|auto-167><vspace|0.5fn>
+      <no-break><pageref|auto-168><vspace|0.5fn>
 
       <vspace*|1fn><with|font-series|<quote|bold>|math-font-series|<quote|bold>|Bibliography>
       <datoms|<macro|x|<repeat|<arg|x>|<with|font-series|medium|<with|font-size|1|<space|0.2fn>.<space|0.2fn>>>>>|<htab|5mm>>
-      <no-break><pageref|auto-168><vspace|0.5fn>
+      <no-break><pageref|auto-169><vspace|0.5fn>
     </associate>
   </collection>
 </auxiliary>


### PR DESCRIPTION
This new order allows for a `disconnect iden t` idiom which I think will be a common use case for `disconnect`.  The forthcoming "universal sighash" work uses this idiom.