### PR TITLE
adds a stack configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ Haskell/*.pdf
 Simplicity.cabal
 dist-newstyle/
 result-doc
+.stack-work/*
+stack.yaml.lock

--- a/Simplicity-Bitcoin.cabal.delete-this-extension
+++ b/Simplicity-Bitcoin.cabal.delete-this-extension
@@ -11,7 +11,7 @@ category:            Language
 build-type:          Simple
 extra-source-files:  README.md
 cabal-version:       >=1.25
-tested-with:         GHC ==8.6.4
+tested-with:         GHC ==8.6.5
 
 library
   exposed-modules:     Simplicity.Ty, Simplicity.Ty.Bit, Simplicity.Ty.Word,

--- a/Simplicity-Elements.cabal.delete-this-extension
+++ b/Simplicity-Elements.cabal.delete-this-extension
@@ -11,7 +11,7 @@ category:            Language
 build-type:          Simple
 extra-source-files:  README.md
 cabal-version:       >=1.25
-tested-with:         GHC ==8.6.4
+tested-with:         GHC ==8.6.5
 
 library
   exposed-modules:     Simplicity.Ty, Simplicity.Ty.Bit, Simplicity.Ty.Word,

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,14 +1,6 @@
-# This is the implicit global project's config file, which is only used when
-# 'stack' is run outside of a real project.  Settings here do _not_ act as
-# defaults for all projects.  To change stack's default settings, edit
-# '/Users/keagan/.stack/config.yaml' instead.
-#
-# For more information about stack's configuration, see
-# http://docs.haskellstack.org/en/stable/yaml_configuration/
-#
 packages:
 - .
-resolver: lts-14.27
+resolver: lts-14.27 # GHC 8.6.5 last package set
 extra-deps:
   - lens-family-2.0.0
   - lens-family-core-2.0.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,14 @@
+# This is the implicit global project's config file, which is only used when
+# 'stack' is run outside of a real project.  Settings here do _not_ act as
+# defaults for all projects.  To change stack's default settings, edit
+# '/Users/keagan/.stack/config.yaml' instead.
+#
+# For more information about stack's configuration, see
+# http://docs.haskellstack.org/en/stable/yaml_configuration/
+#
+packages:
+- .
+resolver: lts-13.19
+extra-deps:
+  - lens-family-2.0.0
+  - lens-family-core-2.0.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -8,7 +8,7 @@
 #
 packages:
 - .
-resolver: lts-13.19
+resolver: lts-14.27
 extra-deps:
   - lens-family-2.0.0
   - lens-family-core-2.0.0


### PR DESCRIPTION
The choice of LTS-13.19 was derived from the Cabal file that stated it used GHC 8.6.4. If you would prefer library sets from newer GHC versions let me know and I'll find the right LTS set.