### PR TITLE
Fix simplicity build eqmod_mod error

### DIFF
--- a/Coq/Simplicity/SHA256.v
+++ b/Coq/Simplicity/SHA256.v
@@ -334,7 +334,7 @@ split.
   rewrite to_fromZ.
   symmetry.
   apply Int.eqm_samerepr.
-  apply Zbits.eqmod_mod.
+  apply Int.eqmod_mod.
   reflexivity.
  repeat f_equal;
   rewrite !add32_correct, ?majWord32_Maj, chWord32_Ch,


### PR DESCRIPTION
This PR fixes #57, where what I assume is a typo is causing build error for Simplicity project. 

When building without Nix, the following error appears after running `make -f CoqMakefile`

```
COQC Simplicity/SHA256.v
File "./Simplicity/SHA256.v", line 337, characters 8-23:
Error: The reference Zbits.eqmod_mod was not found in the current
environment.

make[1]: *** [Simplicity/SHA256.vo] Error 1
make: *** [all] Error 2
```

I'm assuming this is a typo where

`apply Zbits.eqmod_mod` should be `apply Int.eqmod_mod`

