### PR TITLE
Implement radix sort for 256-bit hash values.

### DIFF
--- a/C/Makefile
+++ b/C/Makefile
@@ -1,4 +1,4 @@
-OBJS := bitstream.o dag.o deserialize.o eval.o frame.o jets.o sha256.o type.o typeInference.o primitive/elements.o primitive/elements/jets.o primitive/elements/primitive.o
+OBJS := bitstream.o dag.o deserialize.o eval.o frame.o jets.o rsort.o sha256.o type.o typeInference.o primitive/elements.o primitive/elements/jets.o primitive/elements/primitive.o
 TEST_OBJS := test.o hashBlock.o schnorr0.o schnorr6.o primitive/elements/checkSigHashAllTx1.o
 
 # From https://fastcompression.blogspot.com/2019/01/compiler-warnings.html

--- a/C/rsort.c
+++ b/C/rsort.c
@@ -1,0 +1,123 @@
+#include "rsort.h"
+
+#include <assert.h>
+#include <string.h>
+
+/* Return the 'i'th char of the internal representation of the midstate pointed to by a.
+ *
+ * Precondition: NULL != a
+ *               i < sizeof(a->s);
+ */
+static unsigned char readLevel(const sha256_midstate* a, size_t i) {
+  return ((const unsigned char*)(a->s))[i];
+}
+
+/* Given an array of midstate pointers,
+ * count the frequencies of the values of the 'j'th character of each midstate's internal representation.
+ *
+ * The time complexity of 'freq' is O('len').
+ *
+ * Precondition: size_t result[CHAR_COUNT];
+ *               const sha256_midstate * const a[len];
+ *               j < sizeof((*a)->s)
+ */
+static void freq(size_t* result, const sha256_midstate * const * a, size_t len, size_t j) {
+  memset(result, 0, CHAR_COUNT * sizeof(size_t));
+
+  for (size_t i = 0; i < len; ++i) {
+    result[readLevel(a[i],j)]++;
+  }
+}
+
+/* Given an array of bucket sizes, return an array of their cumulative sizes.
+ *
+ * Precondition: size_t result[CHAR_COUNT];
+ *               const size_t sizes[CHAR_COUNT];
+ */
+static void cumulative(size_t* restrict result, const size_t* restrict sizes) {
+  size_t accumulator = 0;
+
+  for (size_t i = 0; i < CHAR_COUNT; ++i) {
+    accumulator += sizes[i];
+    result[i] = accumulator;
+  }
+}
+
+/* Given an array of bucket end indices (i.e. the result of 'cumulative'),
+ * Return the starting position of the 'i'th bucket.
+ *
+ * Precondition: size_t ends[CHAR_COUNT];
+ *               i < CHAR_COUNT;
+ */
+static size_t bucketStart(const size_t* ends, size_t i) {
+  return i ? ends[i-1] : 0;
+}
+
+/* Exchange two pointers.
+ * (a == b is acceptable.)
+ *
+ * Precondition: NULL != a;
+ *               NULL != b;
+ */
+static void swap(const sha256_midstate** a, const sha256_midstate** b) {
+  const sha256_midstate* tmp = *a;
+  *a = *b;
+  *b = tmp;
+}
+
+/* Attempts to (partially) sort an array of pointers to 'sha256_midstate's in place in an implementation specific order.
+ * If duplicate entries are found, the sorting is aborted and one of pointers to a duplicate entry is returned.
+ * Otherwise if no duplicate entires are found 'NULL' is returned.
+ * The sort order is determined by the first 'level' 'char's of the internal represenation of 'sha256_midsate'.
+ *
+ * The maximum recursion depth is 'level'.  With some effort 'rsort' could be rewritten to be non-recursive.
+ * The time complexity of rsort is O('len').
+ *
+ * Precondition: size_t scratch[(level + 1)*CHAR_COUNT];
+ *               For all 0 <= i < len, NULL != a[i];
+ *               level <= sizeof((*a)->s);
+ */
+const sha256_midstate* rsort(size_t* scratch, const sha256_midstate** a, size_t len, size_t level) {
+  /* An array of length 0 or 1 is sorted and without duplicates. */
+  if (len < 2) return NULL;
+
+  /* An array of empty strings of length 2 or more has duplicates. */
+  if (0 == level) return a[0];
+
+  assert(level <= sizeof((*a)->s));
+
+  size_t* bucketEnds = scratch;
+
+  {
+    size_t* bucketSize = scratch + CHAR_COUNT;
+
+    /* The time complexity of 'freq' is O('len'). */
+    freq(bucketSize, a, len, level - 1);
+    cumulative(bucketEnds, bucketSize);
+    assert(len == bucketEnds[UCHAR_MAX]);
+
+    for (size_t i = 0; i < CHAR_COUNT; ++i) {
+      size_t start = bucketStart(bucketEnds, i);
+      while (bucketSize[i]) {
+        /* Each time through this loop some bucketSize is decremented.
+         * Therefore this body is exectued 'len' many times per call to rsort.
+         */
+        size_t bucket = readLevel(a[start], level - 1);
+        assert(bucketSize[bucket]);
+        bucketSize[bucket]--;
+        swap(a + start, a + bucketStart(bucketEnds, bucket) + bucketSize[bucket]);
+      }
+    }
+  }
+
+  for (size_t i = 0; i < CHAR_COUNT; ++i) {
+    size_t start = bucketStart(bucketEnds, i);
+    /* By induction this rsort call takes O('bucketEnds'['i'] - 'start') time.
+     * There is one call per bucket, so the total cost of these recursive calls is O('len').
+     */
+    const sha256_midstate* rec = rsort(scratch + CHAR_COUNT, a + start, bucketEnds[i] - start, level - 1);
+    if (rec) return rec;
+  }
+
+  return NULL;
+}

--- a/C/rsort.h
+++ b/C/rsort.h
@@ -1,0 +1,43 @@
+#ifndef SIMPLICITY_RSORT_H
+#define SIMPLICITY_RSORT_H
+
+#include <limits.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#include "sha256.h"
+
+_Static_assert(UCHAR_MAX < SIZE_MAX, "UCHAR_MAX >= SIZE_MAX");
+#define CHAR_COUNT ((size_t)1 << CHAR_BIT)
+
+/* Internal function used by 'hasDuplicates'.  Do not call directly. */
+const sha256_midstate* rsort(size_t* scratch, const sha256_midstate** a, size_t len, size_t level);
+
+/* Searches for duplicates in an array of pointers to 'sha256_midstate's.
+ * If 'true' is returned, '*duplicates' is set according to whether duplicate 'sha256_midstate' values were found.
+ * If 'true' is returned, the array is also wiped, with all pointers set to NULL.
+ * If malloc fails, false is returned and '*duplicates' and the array are unchanged.
+ *
+ * Precondition: NULL != duplicates;
+ *               For all 0 <= i < len, NULL != a[i];
+ * Postcondition: If 'true' is returned then for all 0 <= i < len, NULL == a[i];
+ */
+static inline bool hasDuplicates(bool* duplicates, const sha256_midstate** a, size_t len) {
+  _Static_assert(sizeof((*a)->s) * CHAR_BIT == 256, "sha256_midstate.s has unnamed padding");
+  _Static_assert(sizeof((*a)->s) < SIZE_MAX / CHAR_COUNT, "CHAR_BIT is way too large");
+  _Static_assert((sizeof((*a)->s) + 1) * CHAR_COUNT <= SIZE_MAX/sizeof(size_t), "sizeof(size_t) is way too large");
+  size_t * scratch = malloc((sizeof((*a)->s) + 1) * CHAR_COUNT * sizeof(size_t));
+
+  if (scratch) {
+    *duplicates = rsort(scratch, a, len, sizeof((*a)->s));
+
+    /* Censor the array because its current order is implemenation defined. */
+    while (len) { a[--len] = NULL; }
+  }
+
+  free(scratch);
+  return scratch;
+}
+
+#endif


### PR DESCRIPTION
The 'hasDuplicates' function is not yet used by the Simplicity interpreter, however it will be used to ensure that every node's identity Merkle root is unique.