### PR TITLE
C: clean up build a bit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,10 @@ Simplicity-TR.pdf
 Haskell/*.pdf
 *.eps
 result-doc
+
+*.a
+*.log
+*.o
+*.so
+C/test
+

--- a/C/Makefile
+++ b/C/Makefile
@@ -13,11 +13,12 @@ ifneq ($(strip $(SINGLE_THREADED)),)
   CPPFLAGS := $(CPPFLAGS) -DSINGLE_THREADED
 endif
 
-CFLAGS := -I include
+CFLAGS := $(CFLAGS) -I include -I ../libsha256compression/include
+LDFLAGS := $(LDFLAGS) -L ../libsha256compression/
 
 ifeq ($(strip $(SINGLE_THREADED)),)
   # SINGLE_THREADED is empty
-  LDFLAGS := -pthread
+  LDFLAGS := $(LDFLAGS) -pthread
 endif
 
 LDLIBS := -lsha256compression


### PR DESCRIPTION
Cleans up the `Makefile` so that things will buid without needing to change CFLAGS and LDFLAGS.

It's still not great; you still need to manually build `libsha256compression/` before building `C/` and you still need to specify `LD_LIBRARY_PATH=../libsha256compression` before running the test binary, but it's progress.