### PR TITLE
Eliminate constant time fe_normalize.

### DIFF
--- a/C/jets-secp256k1.c
+++ b/C/jets-secp256k1.c
@@ -14,7 +14,7 @@ static inline void read_fe(secp256k1_fe* r, frameItem* src) {
   unsigned char buf[32];
 
   read8s(buf, 32, src);
-  if (!secp256k1_fe_set_b32(r, buf)) secp256k1_fe_normalize(r);
+  if (!secp256k1_fe_set_b32(r, buf)) secp256k1_fe_normalize_var(r);
 }
 
 /* Write a secp256k1 field element value to the 'dst' frame, advancing the cursor 256 cells.
@@ -26,7 +26,7 @@ static inline void read_fe(secp256k1_fe* r, frameItem* src) {
 static inline void write_fe(frameItem* dst, secp256k1_fe* r) {
   unsigned char buf[32];
 
-  secp256k1_fe_normalize(r);
+  secp256k1_fe_normalize_var(r);
   secp256k1_fe_get_b32(buf, r);
   write8s(dst, buf, 32);
 }
@@ -440,7 +440,7 @@ bool gej_y_is_odd(frameItem* dst, frameItem src, const txEnv* env) {
      writeBit(dst, false);
   } else {
     secp256k1_ge_set_gej_var(&b, &a);
-    secp256k1_fe_normalize(&b.y);
+    secp256k1_fe_normalize_var(&b.y);
     writeBit(dst, secp256k1_fe_is_odd(&b.y));
   }
   return true;

--- a/C/secp256k1/field.h
+++ b/C/secp256k1/field.h
@@ -28,10 +28,12 @@
 #error "Please select wide multiplication implementation"
 #endif
 
+#if 0
 /** Normalize a field element. This brings the field element to a canonical representation, reduces
  *  its magnitude to 1, and reduces it modulo field size `p`.
  */
 static void secp256k1_fe_normalize(secp256k1_fe *r);
+#endif
 
 /** Weakly normalize a field element: reduce its magnitude to 1, but don't fully normalize. */
 static void secp256k1_fe_normalize_weak(secp256k1_fe *r);

--- a/C/secp256k1/field_5x52_impl.h
+++ b/C/secp256k1/field_5x52_impl.h
@@ -47,6 +47,7 @@ static void secp256k1_fe_verify(const secp256k1_fe *a) {
 }
 #endif
 
+#if 0
 static void secp256k1_fe_normalize(secp256k1_fe *r) {
     uint64_t t0 = r->n[0], t1 = r->n[1], t2 = r->n[2], t3 = r->n[3], t4 = r->n[4];
 
@@ -89,6 +90,7 @@ static void secp256k1_fe_normalize(secp256k1_fe *r) {
     secp256k1_fe_verify(r);
 #endif
 }
+#endif
 
 static void secp256k1_fe_normalize_weak(secp256k1_fe *r) {
     uint64_t t0 = r->n[0], t1 = r->n[1], t2 = r->n[2], t3 = r->n[3], t4 = r->n[4];

--- a/C/secp256k1/group_impl.h
+++ b/C/secp256k1/group_impl.h
@@ -605,9 +605,9 @@ static void secp256k1_ge_to_storage(secp256k1_ge_storage *r, const secp256k1_ge 
     secp256k1_fe x, y;
     VERIFY_CHECK(!a->infinity);
     x = a->x;
-    secp256k1_fe_normalize(&x);
+    secp256k1_fe_normalize_var(&x);
     y = a->y;
-    secp256k1_fe_normalize(&y);
+    secp256k1_fe_normalize_var(&y);
     secp256k1_fe_to_storage(&r->x, &x);
     secp256k1_fe_to_storage(&r->y, &y);
 }


### PR DESCRIPTION
There is no nead for it to be in our call graph.