### PR TITLE
Haskell: bump quickcheck max dep version

### DIFF
--- a/Simplicity.cabal
+++ b/Simplicity.cabal
@@ -244,7 +244,7 @@ Test-Suite testsuite
                        cereal >=0.5 && <0.6,
                        containers >=0.5.10 && <0.7,
                        lens-family >=2.0 && <2.2,
-                       QuickCheck >=2.10 && <2.15,
+                       QuickCheck >=2.10 && <2.16,
                        mtl >=2.2 && <2.4,
                        tasty >=0.11 && <1.6,
                        tasty-hunit >=0.9 && <0.11,


### PR DESCRIPTION
Split out from #314, should fix the Haskell CI jobs. The 3 failing Haskell jobs need to be re-run as it seems the Nix installer timed out.